### PR TITLE
fix: critical URDF bugs and round-2 quality improvements

### DIFF
--- a/src/pinocchio_models/addons/pink/ik_solver.py
+++ b/src/pinocchio_models/addons/pink/ik_solver.py
@@ -10,7 +10,6 @@ Usage requires the optional ``pink`` extra::
 
 from __future__ import annotations
 
-import math
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -24,10 +23,14 @@ try:
 except ImportError:
     _HAS_PINK = False
 
-from pinocchio_models.shared.constants import VALID_EXERCISE_NAMES
+import logging
+
+from pinocchio_models.shared.constants import HIP_FLEXION_MAX, VALID_EXERCISE_NAMES
 from pinocchio_models.shared.contracts.preconditions import (
     require_positive,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def _require_pink() -> None:
@@ -233,7 +236,7 @@ def compute_exercise_keyframes(
 
     # Interpolate between phase key positions
     keyframes: list[np.ndarray] = []
-    max_hip_angle = math.radians(120)
+    max_hip_angle = HIP_FLEXION_MAX
 
     for i in range(n_frames):
         t = i / max(n_frames - 1, 1)
@@ -252,7 +255,8 @@ def compute_exercise_keyframes(
         try:
             root_joint_id = model.getJointId("root_joint")
             freeflyer_nq = model.joints[root_joint_id].nq
-        except Exception:
+        except Exception as _e:
+            logger.warning("root_joint not found in model, using fallback nq=7: %s", _e)
             freeflyer_nq = 7  # Fallback for standard FreeFlyer
         nq_actuated = model.nq - freeflyer_nq
         if nq_actuated <= 0:

--- a/src/pinocchio_models/exercises/base.py
+++ b/src/pinocchio_models/exercises/base.py
@@ -19,14 +19,18 @@ from dataclasses import dataclass, field
 from pinocchio_models.shared.barbell import BarbellSpec, create_barbell_links
 from pinocchio_models.shared.body import BodyModelSpec, create_full_body
 from pinocchio_models.shared.contracts.postconditions import ensure_valid_urdf
-from pinocchio_models.shared.utils.urdf_helpers import add_fixed_joint, serialize_model
+from pinocchio_models.shared.utils.urdf_helpers import (
+    add_fixed_joint,
+    add_link,
+    serialize_model,
+)
 
 logger = logging.getLogger(__name__)
 
 
-@dataclass
+@dataclass(frozen=True)
 class ExerciseConfig:
-    """Configuration common to all exercise models."""
+    """Immutable configuration common to all exercise models."""
 
     body_spec: BodyModelSpec = field(default_factory=BodyModelSpec)
     barbell_spec: BarbellSpec = field(default_factory=BarbellSpec.mens_olympic)
@@ -79,6 +83,11 @@ class ExerciseModelBuilder(ABC):
         """
         grip_offset = self.config.barbell_spec.shaft_length * self.grip_offset_fraction
 
+        # Attach barbell_shaft to left hand — barbell_shaft has exactly one parent.
+        # URDF requires each link to have exactly one parent joint; the original
+        # code made barbell_shaft the child of two separate joints (one per hand),
+        # which is topologically invalid. The fix: barbell_shaft is the child of
+        # hand_l only.
         add_fixed_joint(
             robot,
             name="barbell_to_hand_l",
@@ -87,12 +96,27 @@ class ExerciseModelBuilder(ABC):
             origin_xyz=(0, -grip_offset, 0),
         )
 
+        # Add a zero-mass virtual grip anchor for the right hand.  hand_r already
+        # has wrist_r as its parent joint; URDF does not allow a second parent.
+        # The grip_r link hangs off barbell_shaft at the symmetric grip position,
+        # representing the right-hand contact point without creating a kinematic
+        # cycle.  This produces the valid chain:
+        #   hand_l → barbell_shaft → barbell_grip_r  (topology: valid tree)
+        add_link(
+            robot,
+            name="barbell_grip_r",
+            mass=1e-6,
+            origin_xyz=(0, 0, 0),
+            ixx=1e-9,
+            iyy=1e-9,
+            izz=1e-9,
+        )
         add_fixed_joint(
             robot,
             name="barbell_to_hand_r",
-            parent="hand_r",
-            child="barbell_shaft",
-            origin_xyz=(0, grip_offset, 0),
+            parent="barbell_shaft",
+            child="barbell_grip_r",
+            origin_xyz=(0, 2 * grip_offset, 0),
         )
 
     @abstractmethod

--- a/src/pinocchio_models/exercises/clean_and_jerk/clean_and_jerk_model.py
+++ b/src/pinocchio_models/exercises/clean_and_jerk/clean_and_jerk_model.py
@@ -16,6 +16,7 @@ import xml.etree.ElementTree as ET
 
 from pinocchio_models.exercises.base import ExerciseConfig, ExerciseModelBuilder
 from pinocchio_models.shared.constants import (
+    CLEAN_AND_JERK_ANKLE_ANGLE,
     CLEAN_AND_JERK_GRIP_FRACTION,
     CLEAN_AND_JERK_HIP_ANGLE,
     CLEAN_AND_JERK_KNEE_ANGLE,
@@ -55,6 +56,7 @@ class CleanAndJerkModelBuilder(ExerciseModelBuilder):
         set_joint_default(robot, "hip", CLEAN_AND_JERK_HIP_ANGLE)
         set_joint_default(robot, "knee", CLEAN_AND_JERK_KNEE_ANGLE)
         set_joint_default(robot, "lumbar", CLEAN_AND_JERK_LUMBAR_ANGLE)
+        set_joint_default(robot, "ankle", CLEAN_AND_JERK_ANKLE_ANGLE)
 
 
 def build_clean_and_jerk_model(

--- a/src/pinocchio_models/exercises/deadlift/deadlift_model.py
+++ b/src/pinocchio_models/exercises/deadlift/deadlift_model.py
@@ -15,6 +15,7 @@ import xml.etree.ElementTree as ET
 
 from pinocchio_models.exercises.base import ExerciseConfig, ExerciseModelBuilder
 from pinocchio_models.shared.constants import (
+    DEADLIFT_ANKLE_ANGLE,
     DEADLIFT_GRIP_FRACTION,
     DEADLIFT_HIP_ANGLE,
     DEADLIFT_KNEE_ANGLE,
@@ -55,6 +56,7 @@ class DeadliftModelBuilder(ExerciseModelBuilder):
         set_joint_default(robot, "hip", DEADLIFT_HIP_ANGLE)
         set_joint_default(robot, "knee", DEADLIFT_KNEE_ANGLE)
         set_joint_default(robot, "lumbar", DEADLIFT_LUMBAR_ANGLE)
+        set_joint_default(robot, "ankle", DEADLIFT_ANKLE_ANGLE)
 
 
 def build_deadlift_model(

--- a/src/pinocchio_models/exercises/snatch/snatch_model.py
+++ b/src/pinocchio_models/exercises/snatch/snatch_model.py
@@ -16,6 +16,7 @@ import xml.etree.ElementTree as ET
 
 from pinocchio_models.exercises.base import ExerciseConfig, ExerciseModelBuilder
 from pinocchio_models.shared.constants import (
+    SNATCH_ANKLE_ANGLE,
     SNATCH_GRIP_FRACTION,
     SNATCH_HIP_ANGLE,
     SNATCH_KNEE_ANGLE,
@@ -55,6 +56,7 @@ class SnatchModelBuilder(ExerciseModelBuilder):
         set_joint_default(robot, "hip", SNATCH_HIP_ANGLE)
         set_joint_default(robot, "knee", SNATCH_KNEE_ANGLE)
         set_joint_default(robot, "lumbar", SNATCH_LUMBAR_ANGLE)
+        set_joint_default(robot, "ankle", SNATCH_ANKLE_ANGLE)
 
 
 def build_snatch_model(

--- a/src/pinocchio_models/shared/barbell/barbell_model.py
+++ b/src/pinocchio_models/shared/barbell/barbell_model.py
@@ -15,6 +15,7 @@ internal geometry details remain encapsulated.
 
 from __future__ import annotations
 
+import math
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass
 
@@ -119,14 +120,23 @@ def create_barbell_links(
     symmetrically along the Y-axis (left = -Y, right = +Y).
     Z-up convention: barbell lies horizontally in the Y-axis.
     """
-    shaft_inertia = cylinder_inertia(
+    # cylinder_inertia() assumes the cylinder axis is Z.
+    # The barbell lies along Y (sleeves at ±Y offsets), so swap iyy and izz
+    # to correct the axial vs. transverse inertia assignment.
+    # After swap: iyy = 0.5·m·r²  (axial, Y), izz = (1/12)·m·(3r²+L²)  (transverse)
+    _shaft_ixx, _shaft_iyy, _shaft_izz = cylinder_inertia(
         spec.shaft_mass, spec.shaft_radius, spec.shaft_length
     )
+    _shaft_iyy, _shaft_izz = _shaft_izz, _shaft_iyy  # Y-axis cylinder correction
 
     sleeve_total_mass = spec.sleeve_mass + spec.plate_mass_per_side
-    sleeve_inertia = cylinder_inertia(
+    _slv_ixx, _slv_iyy, _slv_izz = cylinder_inertia(
         sleeve_total_mass, spec.sleeve_radius, spec.sleeve_length
     )
+    _slv_iyy, _slv_izz = _slv_izz, _slv_iyy  # Y-axis cylinder correction
+
+    # Rotate visual cylinders 90° about X so they render along Y (not Z).
+    _barbell_visual_rpy = (math.pi / 2, 0.0, 0.0)
 
     shaft_name = f"{prefix}_shaft"
     left_name = f"{prefix}_left_sleeve"
@@ -137,10 +147,11 @@ def create_barbell_links(
         name=shaft_name,
         mass=spec.shaft_mass,
         origin_xyz=(0, 0, 0),
-        ixx=shaft_inertia[0],
-        iyy=shaft_inertia[1],
-        izz=shaft_inertia[2],
+        ixx=_shaft_ixx,
+        iyy=_shaft_iyy,
+        izz=_shaft_izz,
         visual_geometry=make_cylinder_geometry(spec.shaft_radius, spec.shaft_length),
+        visual_origin_rpy=_barbell_visual_rpy,
     )
 
     left_link = add_link(
@@ -148,10 +159,11 @@ def create_barbell_links(
         name=left_name,
         mass=sleeve_total_mass,
         origin_xyz=(0, 0, 0),
-        ixx=sleeve_inertia[0],
-        iyy=sleeve_inertia[1],
-        izz=sleeve_inertia[2],
+        ixx=_slv_ixx,
+        iyy=_slv_iyy,
+        izz=_slv_izz,
         visual_geometry=make_cylinder_geometry(spec.sleeve_radius, spec.sleeve_length),
+        visual_origin_rpy=_barbell_visual_rpy,
     )
 
     right_link = add_link(
@@ -159,10 +171,11 @@ def create_barbell_links(
         name=right_name,
         mass=sleeve_total_mass,
         origin_xyz=(0, 0, 0),
-        ixx=sleeve_inertia[0],
-        iyy=sleeve_inertia[1],
-        izz=sleeve_inertia[2],
+        ixx=_slv_ixx,
+        iyy=_slv_iyy,
+        izz=_slv_izz,
         visual_geometry=make_cylinder_geometry(spec.sleeve_radius, spec.sleeve_length),
+        visual_origin_rpy=_barbell_visual_rpy,
     )
 
     half_shaft = spec.shaft_length / 2.0

--- a/src/pinocchio_models/shared/constants.py
+++ b/src/pinocchio_models/shared/constants.py
@@ -16,12 +16,14 @@ import math
 # Winter (2009) anatomically validated ranges.
 
 # Lumbar spine (flexion/extension about Y)
-LUMBAR_FLEXION_MIN: float = math.radians(-10)  # Extension ~10 deg
+# Kapandji (2008) cites ~20-35° extension; deadlift lockout requires >10°.
+LUMBAR_FLEXION_MIN: float = math.radians(-25)  # Extension ~25 deg
 LUMBAR_FLEXION_MAX: float = math.radians(45)  # Flexion ~45 deg
 
 # Neck (flexion/extension about Y)
-NECK_FLEXION_MIN: float = -math.radians(30)  # -0.5236
-NECK_FLEXION_MAX: float = math.radians(30)  # 0.5236
+# Winter (2009) cites ~50-70° flexion and ~60° extension.
+NECK_FLEXION_MIN: float = math.radians(-60)  # Extension ~60 deg
+NECK_FLEXION_MAX: float = math.radians(70)  # Flexion ~70 deg
 
 # Shoulder (sagittal plane flexion/extension)
 # Extension: -30 deg; Full flexion: 180 deg -- Winter (2009)
@@ -59,6 +61,7 @@ BENCH_PRESS_KNEE_ANGLE: float = -math.radians(90)  # feet flat on floor
 DEADLIFT_HIP_ANGLE: float = math.radians(80)
 DEADLIFT_KNEE_ANGLE: float = -math.radians(60)
 DEADLIFT_LUMBAR_ANGLE: float = math.radians(10)
+DEADLIFT_ANKLE_ANGLE: float = math.radians(18)  # Dorsiflexion at setup
 
 # Squat: standing (unrack position)
 SQUAT_HIP_ANGLE: float = 0.0
@@ -69,11 +72,13 @@ SQUAT_ANKLE_ANGLE: float = 0.0
 SNATCH_HIP_ANGLE: float = math.radians(80)
 SNATCH_KNEE_ANGLE: float = -math.radians(70)
 SNATCH_LUMBAR_ANGLE: float = math.radians(15)
+SNATCH_ANKLE_ANGLE: float = math.radians(20)  # Dorsiflexion at setup (wider stance)
 
 # Clean and jerk: crouched over bar (shoulder-width grip)
 CLEAN_AND_JERK_HIP_ANGLE: float = math.radians(75)
 CLEAN_AND_JERK_KNEE_ANGLE: float = -math.radians(65)
 CLEAN_AND_JERK_LUMBAR_ANGLE: float = math.radians(10)
+CLEAN_AND_JERK_ANKLE_ANGLE: float = math.radians(18)  # Dorsiflexion at setup
 
 # --- Grip width fractions (fraction of shaft length from center) ---
 BENCH_PRESS_GRIP_FRACTION: float = 0.3

--- a/src/pinocchio_models/shared/contracts/postconditions.py
+++ b/src/pinocchio_models/shared/contracts/postconditions.py
@@ -9,14 +9,25 @@ be disabled with ``python -O``.
 
 from __future__ import annotations
 
+import logging
 import xml.etree.ElementTree as ET
+
+logger = logging.getLogger(__name__)
 
 
 def ensure_valid_urdf(xml_string: str) -> ET.Element:
     """Parse *xml_string* and return the root element.
 
-    Validates that the string is well-formed XML with a <robot> root tag.
-    Raises ValueError if the string is not valid URDF.
+    Validates:
+    1. Well-formed XML with a ``<robot>`` root tag.
+    2. Every joint's ``child`` link name exists in the declared link set.
+    3. No link appears as ``child`` of more than one joint (single-parent rule).
+
+    Parent link names are checked with a warning only, because the body model
+    uses resolved parent aliases (e.g. ``torso_l`` → ``torso``) that are
+    structurally intentional and do not need to match a declared link name.
+
+    Raises ValueError if any check fails.
     """
     try:
         root = ET.fromstring(xml_string)  # nosec B314 — parsing self-generated XML
@@ -24,6 +35,50 @@ def ensure_valid_urdf(xml_string: str) -> ET.Element:
         raise ValueError(f"Generated URDF is not well-formed XML: {exc}") from exc
     if root.tag != "robot":
         raise ValueError(f"URDF root must be <robot>, got <{root.tag}>")
+
+    link_names: set[str] = {
+        el.get("name", "") for el in root.findall("link") if el.get("name")
+    }
+
+    child_parent_map: dict[str, str] = {}
+    for joint in root.findall("joint"):
+        joint_name = joint.get("name", "<unnamed>")
+
+        parent_el = joint.find("parent")
+        child_el = joint.find("child")
+        if parent_el is None or child_el is None:
+            continue
+
+        parent_link = parent_el.get("link", "")
+        child_link = child_el.get("link", "")
+
+        # (a) Warn if parent link name does not exist in the declared link set.
+        # This may be intentional for aliased parent links in the body model.
+        if parent_link and parent_link not in link_names:
+            logger.warning(
+                "Joint '%s' references parent link '%s' which is not in the "
+                "declared link set — verify this is intentional",
+                joint_name,
+                parent_link,
+            )
+
+        # (b) Verify child link name exists in the declared link set.
+        if child_link and child_link not in link_names:
+            raise ValueError(
+                f"Joint '{joint_name}' references unknown child link '{child_link}'"
+            )
+
+        # (c) Assert no link appears as child of more than one joint
+        # (URDF single-parent-per-link constraint).
+        if child_link in child_parent_map:
+            raise ValueError(
+                f"Link '{child_link}' is declared as child of both "
+                f"'{child_parent_map[child_link]}' and '{joint_name}' — "
+                "URDF requires each link to have exactly one parent joint"
+            )
+        if child_link:
+            child_parent_map[child_link] = joint_name
+
     return root
 
 

--- a/src/pinocchio_models/shared/utils/urdf_helpers.py
+++ b/src/pinocchio_models/shared/utils/urdf_helpers.py
@@ -31,8 +31,12 @@ which reads those attributes back and returns a numpy array compatible with
 
 from __future__ import annotations
 
+import logging
+import math
 import xml.etree.ElementTree as ET
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 
 def vec3_str(x: float, y: float, z: float) -> str:
@@ -54,9 +58,17 @@ def add_link(
     ixz: float = 0.0,
     iyz: float = 0.0,
     visual_geometry: ET.Element | None = None,
+    visual_origin_rpy: tuple[float, float, float] = (0.0, 0.0, 0.0),
     collision_geometry: ET.Element | None = None,
 ) -> ET.Element:
-    """Append a <link> element with <inertial>, optional <visual>/<collision>."""
+    """Append a <link> element with <inertial>, optional <visual>/<collision>.
+
+    Parameters
+    ----------
+    visual_origin_rpy:
+        Roll-pitch-yaw for the visual geometry origin. Use ``(math.pi/2, 0, 0)``
+        to rotate a cylinder from its default Z-axis orientation to lie along Y.
+    """
     link = ET.SubElement(robot, "link", name=name)
 
     # Inertial
@@ -81,7 +93,12 @@ def add_link(
 
     if visual_geometry is not None:
         visual = ET.SubElement(link, "visual")
-        ET.SubElement(visual, "origin", xyz="0 0 0", rpy="0 0 0")
+        ET.SubElement(
+            visual,
+            "origin",
+            xyz="0 0 0",
+            rpy=vec3_str(*visual_origin_rpy),
+        )
         visual.append(visual_geometry)
 
     if collision_geometry is not None:
@@ -101,8 +118,8 @@ def add_revolute_joint(
     origin_xyz: tuple[float, float, float] = (0, 0, 0),
     origin_rpy: tuple[float, float, float] = (0, 0, 0),
     axis: tuple[float, float, float] = (0, 0, 1),
-    lower: float = -1.5708,
-    upper: float = 1.5708,
+    lower: float = -math.pi / 2,
+    upper: float = math.pi / 2,
     effort: float = 1000.0,
     velocity: float = 10.0,
 ) -> ET.Element:
@@ -271,7 +288,8 @@ def get_initial_configuration(model: Any, xml_str: str) -> Any:
         joint_name = joint_el.get("name", "")
         try:
             joint_id = model.getJointId(joint_name)
-        except Exception:
+        except Exception as _e:
+            logger.warning("Joint %s not found in model: %s", joint_name, _e)
             continue
         if joint_id >= len(model.joints):
             continue

--- a/tests/unit/exercises/test_bench_press.py
+++ b/tests/unit/exercises/test_bench_press.py
@@ -1,10 +1,19 @@
 """Tests for bench press model builder."""
 
+import math
 import xml.etree.ElementTree as ET
+
+import pytest
 
 from pinocchio_models.exercises.bench_press.bench_press_model import (
     BenchPressModelBuilder,
     build_bench_press_model,
+)
+from pinocchio_models.shared.constants import (
+    BENCH_PRESS_ELBOW_ANGLE,
+    BENCH_PRESS_HIP_ANGLE,
+    BENCH_PRESS_KNEE_ANGLE,
+    BENCH_PRESS_SHOULDER_ANGLE,
 )
 
 
@@ -64,6 +73,62 @@ class TestBenchPressModelBuilder:
         ]
         for j in shoulder_joints:
             assert j.get("initial_position") is not None
+            assert float(j.get("initial_position")) == pytest.approx(
+                BENCH_PRESS_SHOULDER_ANGLE, abs=1e-4
+            )
+
+    def test_initial_pose_elbow_defaults(self) -> None:
+        xml_str = build_bench_press_model()
+        root = ET.fromstring(xml_str)
+        elbow_joints = [
+            j for j in root.findall("joint") if j.get("name", "").startswith("elbow_")
+        ]
+        for j in elbow_joints:
+            assert j.get("initial_position") is not None
+            assert float(j.get("initial_position")) == pytest.approx(
+                BENCH_PRESS_ELBOW_ANGLE, abs=1e-4
+            )
+
+    def test_initial_pose_hip_defaults(self) -> None:
+        xml_str = build_bench_press_model()
+        root = ET.fromstring(xml_str)
+        hip_joints = [
+            j for j in root.findall("joint") if j.get("name", "").startswith("hip_")
+        ]
+        for j in hip_joints:
+            assert j.get("initial_position") is not None
+            assert float(j.get("initial_position")) == pytest.approx(
+                BENCH_PRESS_HIP_ANGLE, abs=1e-4
+            )
+
+    def test_initial_pose_knee_defaults(self) -> None:
+        xml_str = build_bench_press_model()
+        root = ET.fromstring(xml_str)
+        knee_joints = [
+            j for j in root.findall("joint") if j.get("name", "").startswith("knee_")
+        ]
+        for j in knee_joints:
+            assert j.get("initial_position") is not None
+            assert float(j.get("initial_position")) == pytest.approx(
+                BENCH_PRESS_KNEE_ANGLE, abs=1e-4
+            )
+
+    def test_shoulder_angle_within_limits(self) -> None:
+        """Shoulder initial angle must be within anatomical ROM."""
+        from pinocchio_models.shared.constants import (
+            SHOULDER_FLEXION_MAX,
+            SHOULDER_FLEXION_MIN,
+        )
+
+        assert (
+            SHOULDER_FLEXION_MIN <= BENCH_PRESS_SHOULDER_ANGLE <= SHOULDER_FLEXION_MAX
+        )
+
+    def test_knee_angle_within_limits(self) -> None:
+        """Knee initial angle must be within anatomical ROM."""
+        from pinocchio_models.shared.constants import KNEE_FLEXION_MAX, KNEE_FLEXION_MIN
+
+        assert KNEE_FLEXION_MIN <= BENCH_PRESS_KNEE_ANGLE <= KNEE_FLEXION_MAX
 
     def test_custom_body_parameters(self) -> None:
         xml_str = build_bench_press_model(body_mass=100.0, height=1.90)
@@ -71,3 +136,7 @@ class TestBenchPressModelBuilder:
         assert root.tag == "robot"
         links = root.findall("link")
         assert len(links) >= 18
+
+    def test_shoulder_angle_is_90_degrees(self) -> None:
+        """Bench press lockout: shoulders at 90 degrees (arms pointing up)."""
+        assert pytest.approx(math.radians(90.0), abs=1e-6) == BENCH_PRESS_SHOULDER_ANGLE

--- a/tests/unit/exercises/test_clean_and_jerk.py
+++ b/tests/unit/exercises/test_clean_and_jerk.py
@@ -1,10 +1,18 @@
 """Tests for clean and jerk model builder."""
 
+import math
 import xml.etree.ElementTree as ET
+
+import pytest
 
 from pinocchio_models.exercises.clean_and_jerk.clean_and_jerk_model import (
     CleanAndJerkModelBuilder,
     build_clean_and_jerk_model,
+)
+from pinocchio_models.shared.constants import (
+    CLEAN_AND_JERK_ANKLE_ANGLE,
+    CLEAN_AND_JERK_HIP_ANGLE,
+    CLEAN_AND_JERK_KNEE_ANGLE,
 )
 
 
@@ -49,6 +57,58 @@ class TestCleanAndJerkModelBuilder:
         ]
         for j in hip_joints:
             assert j.get("initial_position") is not None
+            assert float(j.get("initial_position")) == pytest.approx(
+                CLEAN_AND_JERK_HIP_ANGLE, abs=1e-4
+            )
+
+    def test_initial_pose_knee_defaults(self) -> None:
+        xml_str = build_clean_and_jerk_model()
+        root = ET.fromstring(xml_str)
+        knee_joints = [
+            j for j in root.findall("joint") if j.get("name", "").startswith("knee_")
+        ]
+        for j in knee_joints:
+            assert j.get("initial_position") is not None
+            assert float(j.get("initial_position")) == pytest.approx(
+                CLEAN_AND_JERK_KNEE_ANGLE, abs=1e-4
+            )
+
+    def test_initial_pose_ankle_defaults(self) -> None:
+        xml_str = build_clean_and_jerk_model()
+        root = ET.fromstring(xml_str)
+        ankle_joints = [
+            j for j in root.findall("joint") if j.get("name", "").startswith("ankle_")
+        ]
+        for j in ankle_joints:
+            assert j.get("initial_position") is not None
+            assert float(j.get("initial_position")) == pytest.approx(
+                CLEAN_AND_JERK_ANKLE_ANGLE, abs=1e-4
+            )
+
+    def test_hip_angle_is_75_degrees(self) -> None:
+        """Clean-and-jerk setup: hips at 75 degrees flexion."""
+        assert pytest.approx(math.radians(75.0), abs=1e-6) == CLEAN_AND_JERK_HIP_ANGLE
+
+    def test_hip_angle_within_limits(self) -> None:
+        """Hip initial angle must be within anatomical ROM."""
+        from pinocchio_models.shared.constants import HIP_FLEXION_MAX, HIP_FLEXION_MIN
+
+        assert HIP_FLEXION_MIN <= CLEAN_AND_JERK_HIP_ANGLE <= HIP_FLEXION_MAX
+
+    def test_knee_angle_within_limits(self) -> None:
+        """Knee initial angle must be within anatomical ROM."""
+        from pinocchio_models.shared.constants import KNEE_FLEXION_MAX, KNEE_FLEXION_MIN
+
+        assert KNEE_FLEXION_MIN <= CLEAN_AND_JERK_KNEE_ANGLE <= KNEE_FLEXION_MAX
+
+    def test_ankle_angle_within_limits(self) -> None:
+        """Ankle initial angle must be within anatomical ROM."""
+        from pinocchio_models.shared.constants import (
+            ANKLE_FLEXION_MAX,
+            ANKLE_FLEXION_MIN,
+        )
+
+        assert ANKLE_FLEXION_MIN <= CLEAN_AND_JERK_ANKLE_ANGLE <= ANKLE_FLEXION_MAX
 
     def test_custom_body_parameters(self) -> None:
         xml_str = build_clean_and_jerk_model(body_mass=90.0, height=1.80)

--- a/tests/unit/exercises/test_deadlift.py
+++ b/tests/unit/exercises/test_deadlift.py
@@ -1,10 +1,18 @@
 """Tests for deadlift model builder."""
 
+import math
 import xml.etree.ElementTree as ET
+
+import pytest
 
 from pinocchio_models.exercises.deadlift.deadlift_model import (
     DeadliftModelBuilder,
     build_deadlift_model,
+)
+from pinocchio_models.shared.constants import (
+    DEADLIFT_ANKLE_ANGLE,
+    DEADLIFT_HIP_ANGLE,
+    DEADLIFT_KNEE_ANGLE,
 )
 
 
@@ -56,6 +64,58 @@ class TestDeadliftModelBuilder:
         ]
         for j in hip_joints:
             assert j.get("initial_position") is not None
+            assert float(j.get("initial_position")) == pytest.approx(
+                DEADLIFT_HIP_ANGLE, abs=1e-4
+            )
+
+    def test_initial_pose_sets_knee_defaults(self) -> None:
+        xml_str = build_deadlift_model()
+        root = ET.fromstring(xml_str)
+        knee_joints = [
+            j for j in root.findall("joint") if j.get("name", "").startswith("knee_")
+        ]
+        for j in knee_joints:
+            assert j.get("initial_position") is not None
+            assert float(j.get("initial_position")) == pytest.approx(
+                DEADLIFT_KNEE_ANGLE, abs=1e-4
+            )
+
+    def test_initial_pose_sets_ankle_defaults(self) -> None:
+        xml_str = build_deadlift_model()
+        root = ET.fromstring(xml_str)
+        ankle_joints = [
+            j for j in root.findall("joint") if j.get("name", "").startswith("ankle_")
+        ]
+        for j in ankle_joints:
+            assert j.get("initial_position") is not None
+            assert float(j.get("initial_position")) == pytest.approx(
+                DEADLIFT_ANKLE_ANGLE, abs=1e-4
+            )
+
+    def test_hip_angle_is_80_degrees(self) -> None:
+        """Deadlift setup: hips at 80 degrees flexion."""
+        assert pytest.approx(math.radians(80.0), abs=1e-6) == DEADLIFT_HIP_ANGLE
+
+    def test_hip_angle_within_limits(self) -> None:
+        """Hip initial angle must be within anatomical ROM."""
+        from pinocchio_models.shared.constants import HIP_FLEXION_MAX, HIP_FLEXION_MIN
+
+        assert HIP_FLEXION_MIN <= DEADLIFT_HIP_ANGLE <= HIP_FLEXION_MAX
+
+    def test_knee_angle_within_limits(self) -> None:
+        """Knee initial angle must be within anatomical ROM."""
+        from pinocchio_models.shared.constants import KNEE_FLEXION_MAX, KNEE_FLEXION_MIN
+
+        assert KNEE_FLEXION_MIN <= DEADLIFT_KNEE_ANGLE <= KNEE_FLEXION_MAX
+
+    def test_ankle_angle_within_limits(self) -> None:
+        """Ankle initial angle must be within anatomical ROM."""
+        from pinocchio_models.shared.constants import (
+            ANKLE_FLEXION_MAX,
+            ANKLE_FLEXION_MIN,
+        )
+
+        assert ANKLE_FLEXION_MIN <= DEADLIFT_ANKLE_ANGLE <= ANKLE_FLEXION_MAX
 
     def test_custom_body_parameters(self) -> None:
         xml_str = build_deadlift_model(body_mass=100.0, height=1.90)

--- a/tests/unit/exercises/test_snatch.py
+++ b/tests/unit/exercises/test_snatch.py
@@ -1,10 +1,18 @@
 """Tests for snatch model builder."""
 
+import math
 import xml.etree.ElementTree as ET
+
+import pytest
 
 from pinocchio_models.exercises.snatch.snatch_model import (
     SnatchModelBuilder,
     build_snatch_model,
+)
+from pinocchio_models.shared.constants import (
+    SNATCH_ANKLE_ANGLE,
+    SNATCH_HIP_ANGLE,
+    SNATCH_KNEE_ANGLE,
 )
 
 
@@ -54,6 +62,58 @@ class TestSnatchModelBuilder:
         ]
         for j in hip_joints:
             assert j.get("initial_position") is not None
+            assert float(j.get("initial_position")) == pytest.approx(
+                SNATCH_HIP_ANGLE, abs=1e-4
+            )
+
+    def test_initial_pose_knee_defaults(self) -> None:
+        xml_str = build_snatch_model()
+        root = ET.fromstring(xml_str)
+        knee_joints = [
+            j for j in root.findall("joint") if j.get("name", "").startswith("knee_")
+        ]
+        for j in knee_joints:
+            assert j.get("initial_position") is not None
+            assert float(j.get("initial_position")) == pytest.approx(
+                SNATCH_KNEE_ANGLE, abs=1e-4
+            )
+
+    def test_initial_pose_ankle_defaults(self) -> None:
+        xml_str = build_snatch_model()
+        root = ET.fromstring(xml_str)
+        ankle_joints = [
+            j for j in root.findall("joint") if j.get("name", "").startswith("ankle_")
+        ]
+        for j in ankle_joints:
+            assert j.get("initial_position") is not None
+            assert float(j.get("initial_position")) == pytest.approx(
+                SNATCH_ANKLE_ANGLE, abs=1e-4
+            )
+
+    def test_hip_angle_is_80_degrees(self) -> None:
+        """Snatch setup: hips at 80 degrees flexion."""
+        assert pytest.approx(math.radians(80.0), abs=1e-6) == SNATCH_HIP_ANGLE
+
+    def test_hip_angle_within_limits(self) -> None:
+        """Hip initial angle must be within anatomical ROM."""
+        from pinocchio_models.shared.constants import HIP_FLEXION_MAX, HIP_FLEXION_MIN
+
+        assert HIP_FLEXION_MIN <= SNATCH_HIP_ANGLE <= HIP_FLEXION_MAX
+
+    def test_knee_angle_within_limits(self) -> None:
+        """Knee initial angle must be within anatomical ROM."""
+        from pinocchio_models.shared.constants import KNEE_FLEXION_MAX, KNEE_FLEXION_MIN
+
+        assert KNEE_FLEXION_MIN <= SNATCH_KNEE_ANGLE <= KNEE_FLEXION_MAX
+
+    def test_ankle_angle_within_limits(self) -> None:
+        """Ankle initial angle must be within anatomical ROM."""
+        from pinocchio_models.shared.constants import (
+            ANKLE_FLEXION_MAX,
+            ANKLE_FLEXION_MIN,
+        )
+
+        assert ANKLE_FLEXION_MIN <= SNATCH_ANKLE_ANGLE <= ANKLE_FLEXION_MAX
 
     def test_custom_body_parameters(self) -> None:
         xml_str = build_snatch_model(body_mass=70.0, height=1.65)

--- a/tests/unit/exercises/test_squat.py
+++ b/tests/unit/exercises/test_squat.py
@@ -2,9 +2,16 @@
 
 import xml.etree.ElementTree as ET
 
+import pytest
+
 from pinocchio_models.exercises.squat.squat_model import (
     SquatModelBuilder,
     build_squat_model,
+)
+from pinocchio_models.shared.constants import (
+    SQUAT_ANKLE_ANGLE,
+    SQUAT_HIP_ANGLE,
+    SQUAT_KNEE_ANGLE,
 )
 
 
@@ -63,6 +70,39 @@ class TestSquatModelBuilder:
         ]
         for j in hip_joints:
             assert j.get("initial_position") is not None
+            assert float(j.get("initial_position")) == pytest.approx(
+                SQUAT_HIP_ANGLE, abs=1e-4
+            )
+
+    def test_initial_pose_knee_defaults(self) -> None:
+        xml_str = build_squat_model()
+        root = ET.fromstring(xml_str)
+        knee_joints = [
+            j for j in root.findall("joint") if j.get("name", "").startswith("knee_")
+        ]
+        for j in knee_joints:
+            assert j.get("initial_position") is not None
+            assert float(j.get("initial_position")) == pytest.approx(
+                SQUAT_KNEE_ANGLE, abs=1e-4
+            )
+
+    def test_initial_pose_ankle_defaults(self) -> None:
+        xml_str = build_squat_model()
+        root = ET.fromstring(xml_str)
+        ankle_joints = [
+            j for j in root.findall("joint") if j.get("name", "").startswith("ankle_")
+        ]
+        for j in ankle_joints:
+            assert j.get("initial_position") is not None
+            assert float(j.get("initial_position")) == pytest.approx(
+                SQUAT_ANKLE_ANGLE, abs=1e-4
+            )
+
+    def test_hip_angle_within_limits(self) -> None:
+        """Hip initial angle must be within anatomical ROM."""
+        from pinocchio_models.shared.constants import HIP_FLEXION_MAX, HIP_FLEXION_MIN
+
+        assert HIP_FLEXION_MIN <= SQUAT_HIP_ANGLE <= HIP_FLEXION_MAX
 
     def test_custom_body_parameters(self) -> None:
         xml_str = build_squat_model(


### PR DESCRIPTION
## Summary

- **CRITICAL (issues #38, #39, #40):** Fix three barbell URDF bugs: dual-parent kinematic tree (replaced with `barbell_grip_r` virtual leaf link), swapped Iyy/Izz inertia for Y-axis cylinder (was 1,460x off), and hardcoded Z-axis visual orientation (now rotated pi/2 about X)
- **HIGH (issue #41):** Strengthen `ensure_valid_urdf()` to detect unknown child link names and dual-parent topology violations; log warnings for unresolved parent link aliases
- **HIGH (issues #42, #43):** Fix `compute_exercise_keyframes` to use `HIP_FLEXION_MAX` constant; update lumbar (-25°) and neck (-60°/+70°) ROM per Kapandji 2008; add ankle initial angles for deadlift/snatch/clean_and_jerk
- **HIGH (issue #44):** Replace `is not None` initial-pose assertions with `pytest.approx` numeric checks; add ROM bounds tests in all 5 exercise test files
- **MEDIUM (issue #45):** Replace bare `except Exception: continue` with logged warnings; fix `-1.5708`/`1.5708` magic numbers to `math.pi/2`; make `ExerciseConfig` frozen

## Test plan

- [x] All 227 unit tests pass (`pytest tests/ --ignore=tests/benchmarks`)
- [x] `ruff check src/ tests/` — no issues
- [x] `ruff format src/ tests/` — no changes needed
- [x] Exercise build tests verify URDF is well-formed and passes new postcondition checks
- [x] Initial pose tests now verify specific numeric values for each exercise
- [x] ROM bounds tests confirm all initial angles fall within anatomical limits

🤖 Generated with [Claude Code](https://claude.com/claude-code)