### PR TITLE
Fix parent resolution bug, ankle ROM, and plate inertia

### DIFF
--- a/src/pinocchio_models/shared/barbell/barbell_model.py
+++ b/src/pinocchio_models/shared/barbell/barbell_model.py
@@ -23,7 +23,10 @@ from pinocchio_models.shared.contracts.preconditions import (
     require_non_negative,
     require_positive,
 )
-from pinocchio_models.shared.utils.geometry import cylinder_inertia
+from pinocchio_models.shared.utils.geometry import (
+    cylinder_inertia,
+    hollow_cylinder_inertia,
+)
 from pinocchio_models.shared.utils.urdf_helpers import (
     add_fixed_joint,
     add_link,
@@ -129,11 +132,27 @@ def create_barbell_links(
     )
     _shaft_iyy, _shaft_izz = _shaft_izz, _shaft_iyy  # Y-axis cylinder correction
 
-    sleeve_total_mass = spec.sleeve_mass + spec.plate_mass_per_side
+    # Compute bare sleeve inertia
     _slv_ixx, _slv_iyy, _slv_izz = cylinder_inertia(
-        sleeve_total_mass, spec.sleeve_radius, spec.sleeve_length
+        spec.sleeve_mass, spec.sleeve_radius, spec.sleeve_length
     )
     _slv_iyy, _slv_izz = _slv_izz, _slv_iyy  # Y-axis cylinder correction
+
+    # Add plate inertia using correct plate radius (0.225 m), not sleeve radius
+    if spec.plate_mass_per_side > 0:
+        plate_thickness = max(0.01, spec.plate_mass_per_side * 0.002)
+        _plt_ixx, _plt_iyy, _plt_izz = hollow_cylinder_inertia(
+            spec.plate_mass_per_side,
+            inner_radius=spec.sleeve_radius,
+            outer_radius=0.225,
+            length=plate_thickness,
+        )
+        _plt_iyy, _plt_izz = _plt_izz, _plt_iyy  # Y-axis cylinder correction
+        _slv_ixx += _plt_ixx
+        _slv_iyy += _plt_iyy
+        _slv_izz += _plt_izz
+
+    sleeve_total_mass = spec.sleeve_mass + spec.plate_mass_per_side
 
     # Rotate visual cylinders 90° about X so they render along Y (not Z).
     _barbell_visual_rpy = (math.pi / 2, 0.0, 0.0)

--- a/src/pinocchio_models/shared/body/body_model.py
+++ b/src/pinocchio_models/shared/body/body_model.py
@@ -95,6 +95,14 @@ _SEGMENT_TABLE: dict[str, dict[str, float]] = {
 }
 
 
+# Segments that are duplicated bilaterally (_l and _r suffixes).
+# Central segments (pelvis, torso, head) are NOT bilateral and must
+# NOT be resolved with a side suffix.
+_BILATERAL_SEGMENTS: frozenset[str] = frozenset(
+    {"upper_arm", "forearm", "hand", "thigh", "shank", "foot"}
+)
+
+
 def _seg(spec: BodyModelSpec, name: str) -> tuple[float, float, float]:
     """Return (mass, length, radius) for a named segment."""
     s = _SEGMENT_TABLE[name]
@@ -138,7 +146,9 @@ def _add_bilateral_limb(
         )
 
         parent_full = (
-            f"{parent_name}_{side}" if parent_name in _SEGMENT_TABLE else parent_name
+            f"{parent_name}_{side}"
+            if parent_name in _BILATERAL_SEGMENTS
+            else parent_name
         )
         add_revolute_joint(
             robot,

--- a/src/pinocchio_models/shared/constants.py
+++ b/src/pinocchio_models/shared/constants.py
@@ -47,8 +47,8 @@ KNEE_FLEXION_MIN: float = math.radians(-150)  # Full flexion -2.618
 KNEE_FLEXION_MAX: float = math.radians(0)
 
 # Ankle (dorsiflexion/plantarflexion) -- Winter (2009)
-ANKLE_FLEXION_MIN: float = math.radians(-45)  # Plantarflexion
-ANKLE_FLEXION_MAX: float = math.radians(30)  # Dorsiflexion
+ANKLE_FLEXION_MIN: float = math.radians(-50)  # Plantarflexion
+ANKLE_FLEXION_MAX: float = math.radians(20)  # Dorsiflexion
 
 # --- Initial pose angles (radians) for each exercise ---
 # Bench press: arms extended above chest (supine)

--- a/src/pinocchio_models/shared/utils/geometry.py
+++ b/src/pinocchio_models/shared/utils/geometry.py
@@ -44,6 +44,39 @@ def cylinder_inertia(
     return (ixx, iyy, izz)
 
 
+def hollow_cylinder_inertia(
+    mass: float,
+    inner_radius: float,
+    outer_radius: float,
+    length: float,
+) -> tuple[float, float, float]:
+    """Inertia tensor for a hollow cylinder with axis along Z.
+
+    Returns (ixx, iyy, izz) where izz is axial moment, ixx=iyy are transverse.
+
+    Args:
+        mass: Total mass in kg
+        inner_radius: Inner bore radius in metres
+        outer_radius: Outer radius in metres
+        length: Length in metres
+    """
+    require_positive(mass, "mass")
+    require_positive(inner_radius, "inner_radius")
+    require_positive(outer_radius, "outer_radius")
+    require_positive(length, "length")
+    if inner_radius >= outer_radius:
+        raise ValueError(
+            f"inner_radius ({inner_radius:.4f}) must be less than "
+            f"outer_radius ({outer_radius:.4f})"
+        )
+    r_sq_sum = inner_radius**2 + outer_radius**2
+    izz = 0.5 * mass * r_sq_sum  # axial
+    ixx = iyy = (1.0 / 12.0) * mass * (3.0 * r_sq_sum + length**2)  # transverse
+
+    ensure_positive_definite_inertia(ixx, iyy, izz, "hollow_cylinder")
+    return ixx, iyy, izz
+
+
 def rectangular_prism_inertia(
     mass: float, width: float, height: float, depth: float
 ) -> tuple[float, float, float]:


### PR DESCRIPTION
## Summary
- **Parent resolution bug** (#60): Replace `_SEGMENT_TABLE` membership check with `_BILATERAL_SEGMENTS` frozenset containing only bilateral segment names (upper_arm, forearm, hand, thigh, shank, foot). Central segments (pelvis, torso, head) are no longer incorrectly suffixed with `_l`/`_r`
- **Ankle ROM** (#61): Adjust from -45/+30 deg to -50/+20 deg for more anatomically accurate plantarflexion/dorsiflexion limits
- **Plate inertia** (#62): Add `hollow_cylinder_inertia()` and compute plate inertia using correct 0.225m plate radius instead of sleeve radius (0.025m)

Closes #60, closes #61, closes #62

## Test plan
- [x] All 232 existing tests pass
- [x] ruff check and format clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)