### PR TITLE
feat: Rust accelerator, gait & sit-to-stand models, cyclic OCP

### DIFF
--- a/rust_core/Cargo.toml
+++ b/rust_core/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "pinocchio_models_core"
+version = "0.1.0"
+edition = "2021"
+description = "Rust accelerator for Pinocchio Models — parallel batch dynamics and interpolation"
+license = "MIT"
+
+[lib]
+name = "pinocchio_models_core"
+crate-type = ["cdylib"]
+
+[dependencies]
+pyo3 = { version = "0.22", features = ["extension-module"] }
+numpy = "0.22"
+ndarray = "0.16"
+rayon = "1.10"

--- a/rust_core/src/lib.rs
+++ b/rust_core/src/lib.rs
@@ -1,0 +1,202 @@
+//! Rust accelerator for Pinocchio Models.
+//!
+//! Provides parallel batch computations via PyO3 + Rayon:
+//! - `inverse_dynamics_batch()` — parallel batch inverse dynamics (τ = M·q̈ + C·q̇ + g)
+//! - `com_batch()` — parallel batch center-of-mass computation
+//! - `interpolate_phases_rs()` — parallel phase interpolation for keyframe generation
+
+use ndarray::{Array1, Array2, Axis};
+use numpy::{PyArray1, PyArray2, PyReadonlyArray1, PyReadonlyArray2};
+use pyo3::prelude::*;
+use rayon::prelude::*;
+
+/// Compute inverse dynamics in batch: τ = M(q)·q̈ + C(q, q̇)·q̇ + g(q).
+///
+/// This is a simplified rigid-body inverse dynamics using diagonal inertia
+/// approximation for demonstration. For production use, integrate with the
+/// full Pinocchio RNEA algorithm via pin.rnea() on each sample.
+///
+/// # Arguments
+/// * `q_batch`    — joint positions,    shape (batch, nq)
+/// * `qd_batch`   — joint velocities,   shape (batch, nq)
+/// * `qdd_batch`  — joint accelerations, shape (batch, nq)
+/// * `masses`     — per-joint effective masses, shape (nq,)
+/// * `gravity`    — gravitational acceleration magnitude (e.g. 9.81)
+///
+/// # Returns
+/// Torques array of shape (batch, nq).
+#[pyfunction]
+fn inverse_dynamics_batch<'py>(
+    py: Python<'py>,
+    q_batch: PyReadonlyArray2<'py, f64>,
+    qd_batch: PyReadonlyArray2<'py, f64>,
+    qdd_batch: PyReadonlyArray2<'py, f64>,
+    masses: PyReadonlyArray1<'py, f64>,
+    gravity: f64,
+) -> PyResult<Bound<'py, PyArray2<f64>>> {
+    let q = q_batch.as_array();
+    let qd = qd_batch.as_array();
+    let qdd = qdd_batch.as_array();
+    let m = masses.as_array();
+
+    let batch_size = q.nrows();
+    let nq = q.ncols();
+
+    // Pre-allocate output
+    let mut torques = Array2::<f64>::zeros((batch_size, nq));
+
+    // Parallel computation over batch dimension
+    let rows: Vec<Array1<f64>> = (0..batch_size)
+        .into_par_iter()
+        .map(|i| {
+            let mut tau = Array1::<f64>::zeros(nq);
+            for j in 0..nq {
+                // τ_j = m_j * q̈_j + damping * q̇_j + m_j * g
+                let inertia_term = m[j] * qdd[[i, j]];
+                let damping_term = 0.1 * m[j] * qd[[i, j]];
+                let gravity_term = m[j] * gravity * q[[i, j]].cos();
+                tau[j] = inertia_term + damping_term + gravity_term;
+            }
+            tau
+        })
+        .collect();
+
+    for (i, row) in rows.into_iter().enumerate() {
+        torques.row_mut(i).assign(&row);
+    }
+
+    Ok(PyArray2::from_owned_array(py, torques))
+}
+
+/// Compute center of mass for a batch of configurations.
+///
+/// Uses a weighted average of joint positions as a proxy for COM.
+/// Each joint position is weighted by its segment mass.
+///
+/// # Arguments
+/// * `q_batch` — joint positions, shape (batch, nq)
+/// * `masses`  — per-joint segment masses, shape (nq,)
+///
+/// # Returns
+/// COM positions, shape (batch, 3) — [x, y, z] for each sample.
+#[pyfunction]
+fn com_batch<'py>(
+    py: Python<'py>,
+    q_batch: PyReadonlyArray2<'py, f64>,
+    masses: PyReadonlyArray1<'py, f64>,
+) -> PyResult<Bound<'py, PyArray2<f64>>> {
+    let q = q_batch.as_array();
+    let m = masses.as_array();
+
+    let batch_size = q.nrows();
+    let nq = q.ncols();
+    let total_mass: f64 = m.sum();
+
+    let rows: Vec<[f64; 3]> = (0..batch_size)
+        .into_par_iter()
+        .map(|i| {
+            let mut com = [0.0_f64; 3];
+            // Simplified COM: project joint angles to Cartesian via sin/cos
+            for j in 0..nq {
+                let angle = q[[i, j]];
+                com[0] += m[j] * angle.sin();
+                com[1] += m[j] * angle.cos();
+                // Z component accumulates height contribution
+                com[2] += m[j] * (j as f64 / nq as f64);
+            }
+            if total_mass > 0.0 {
+                com[0] /= total_mass;
+                com[1] /= total_mass;
+                com[2] /= total_mass;
+            }
+            com
+        })
+        .collect();
+
+    let mut result = Array2::<f64>::zeros((batch_size, 3));
+    for (i, row) in rows.iter().enumerate() {
+        result[[i, 0]] = row[0];
+        result[[i, 1]] = row[1];
+        result[[i, 2]] = row[2];
+    }
+
+    Ok(PyArray2::from_owned_array(py, result))
+}
+
+/// Parallel phase interpolation for keyframe generation.
+///
+/// Given phase boundary angles and frame fractions, interpolate joint
+/// angles for every frame in parallel.
+///
+/// # Arguments
+/// * `phase_fractions` — sorted phase boundary fractions, shape (n_phases,)
+/// * `phase_angles`    — joint angles at each phase boundary, shape (n_phases, n_joints)
+/// * `n_frames`        — number of output frames
+///
+/// # Returns
+/// Interpolated keyframes, shape (n_frames, n_joints).
+#[pyfunction]
+fn interpolate_phases_rs<'py>(
+    py: Python<'py>,
+    phase_fractions: PyReadonlyArray1<'py, f64>,
+    phase_angles: PyReadonlyArray2<'py, f64>,
+    n_frames: usize,
+) -> PyResult<Bound<'py, PyArray2<f64>>> {
+    let fracs = phase_fractions.as_array();
+    let angles = phase_angles.as_array();
+    let n_joints = angles.ncols();
+    let n_phases = fracs.len();
+
+    let rows: Vec<Array1<f64>> = (0..n_frames)
+        .into_par_iter()
+        .map(|i| {
+            let f = if n_frames > 1 {
+                i as f64 / (n_frames - 1) as f64
+            } else {
+                0.0
+            };
+
+            // Find surrounding phase boundaries
+            let mut prev_idx = 0;
+            let mut next_idx = n_phases - 1;
+            for k in 0..n_phases - 1 {
+                if fracs[k] <= f && f <= fracs[k + 1] {
+                    prev_idx = k;
+                    next_idx = k + 1;
+                    break;
+                }
+            }
+
+            let denom = fracs[next_idx] - fracs[prev_idx];
+            let alpha = if denom.abs() < 1e-15 {
+                0.0
+            } else {
+                (f - fracs[prev_idx]) / denom
+            };
+
+            let mut row = Array1::<f64>::zeros(n_joints);
+            for j in 0..n_joints {
+                let v0 = angles[[prev_idx, j]];
+                let v1 = angles[[next_idx, j]];
+                row[j] = v0 + alpha * (v1 - v0);
+            }
+            row
+        })
+        .collect();
+
+    let mut result = Array2::<f64>::zeros((n_frames, n_joints));
+    for (i, row) in rows.into_iter().enumerate() {
+        result.index_axis_mut(Axis(0), i).assign(&row);
+    }
+
+    Ok(PyArray2::from_owned_array(py, result))
+}
+
+/// Python module definition.
+#[pymodule]
+fn pinocchio_models_core(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(inverse_dynamics_batch, m)?)?;
+    m.add_function(wrap_pyfunction!(com_batch, m)?)?;
+    m.add_function(wrap_pyfunction!(interpolate_phases_rs, m)?)?;
+    Ok(())
+}

--- a/src/pinocchio_models/__init__.py
+++ b/src/pinocchio_models/__init__.py
@@ -13,6 +13,14 @@ from pinocchio_models.exercises.deadlift.deadlift_model import (
     DeadliftModelBuilder,
     build_deadlift_model,
 )
+from pinocchio_models.exercises.gait.gait_model import (
+    GaitModelBuilder,
+    build_gait_model,
+)
+from pinocchio_models.exercises.sit_to_stand.sit_to_stand_model import (
+    SitToStandModelBuilder,
+    build_sit_to_stand_model,
+)
 from pinocchio_models.exercises.snatch.snatch_model import (
     SnatchModelBuilder,
     build_snatch_model,
@@ -32,11 +40,15 @@ __all__ = [
     "DeadliftModelBuilder",
     "ExerciseConfig",
     "ExerciseModelBuilder",
+    "GaitModelBuilder",
+    "SitToStandModelBuilder",
     "SnatchModelBuilder",
     "SquatModelBuilder",
     "build_bench_press_model",
     "build_clean_and_jerk_model",
     "build_deadlift_model",
+    "build_gait_model",
+    "build_sit_to_stand_model",
     "build_snatch_model",
     "build_squat_model",
 ]

--- a/src/pinocchio_models/__main__.py
+++ b/src/pinocchio_models/__main__.py
@@ -22,6 +22,10 @@ from pinocchio_models.exercises.clean_and_jerk.clean_and_jerk_model import (
     build_clean_and_jerk_model,
 )
 from pinocchio_models.exercises.deadlift.deadlift_model import build_deadlift_model
+from pinocchio_models.exercises.gait.gait_model import build_gait_model
+from pinocchio_models.exercises.sit_to_stand.sit_to_stand_model import (
+    build_sit_to_stand_model,
+)
 from pinocchio_models.exercises.snatch.snatch_model import build_snatch_model
 from pinocchio_models.exercises.squat.squat_model import build_squat_model
 from pinocchio_models.shared.constants import VALID_EXERCISE_NAMES
@@ -34,6 +38,8 @@ _BUILDERS: dict[str, Callable[..., str]] = {
     "deadlift": build_deadlift_model,
     "snatch": build_snatch_model,
     "clean_and_jerk": build_clean_and_jerk_model,
+    "gait": build_gait_model,
+    "sit_to_stand": build_sit_to_stand_model,
 }
 
 

--- a/src/pinocchio_models/addons/crocoddyl/optimal_control.py
+++ b/src/pinocchio_models/addons/crocoddyl/optimal_control.py
@@ -39,7 +39,8 @@ def _require_crocoddyl() -> None:
     """Raise ImportError with instructions if Crocoddyl is missing."""
     if not _HAS_CROCODDYL:
         raise ImportError(
-            "Crocoddyl is not installed. " "Install with: pip install pinocchio-models[crocoddyl]"
+            "Crocoddyl is not installed. "
+            "Install with: pip install pinocchio-models[crocoddyl]"
         )
 
 
@@ -47,7 +48,8 @@ def _validate_exercise_name(exercise_name: str) -> None:
     """Validate that exercise_name is a recognized exercise."""
     if exercise_name not in VALID_EXERCISE_NAMES:
         raise ValueError(
-            f"Unknown exercise '{exercise_name}'. " f"Valid names: {sorted(VALID_EXERCISE_NAMES)}"
+            f"Unknown exercise '{exercise_name}'. "
+            f"Valid names: {sorted(VALID_EXERCISE_NAMES)}"
         )
 
 
@@ -199,11 +201,137 @@ def create_exercise_ocp(
         )
 
     # Integrated action models
-    running_models = [crocoddyl.IntegratedActionModelEuler(running_dam, dt) for _ in range(n_steps)]
+    running_models = [
+        crocoddyl.IntegratedActionModelEuler(running_dam, dt) for _ in range(n_steps)
+    ]
     terminal_model = crocoddyl.IntegratedActionModelEuler(terminal_dam, 0.0)
 
     # Shooting problem
     x0 = np.concatenate([pin.neutral(model), np.zeros(model.nv)])
+    problem = crocoddyl.ShootingProblem(x0, running_models, terminal_model)
+
+    return ExerciseOCP(
+        model=model,
+        state=state,
+        actuation=actuation,
+        problem=problem,
+        dt=dt,
+        n_steps=n_steps,
+        running_models=running_models,
+        terminal_model=terminal_model,
+    )
+
+
+def create_cyclic_ocp(
+    urdf_str: str,
+    exercise_name: str,
+    dt: float = 0.01,
+    n_steps: int = 100,
+    *,
+    periodicity_weight: float = 100.0,
+    use_contacts: bool = False,
+) -> ExerciseOCP:
+    """Create an OCP with periodicity constraints for cyclic motion (e.g. gait).
+
+    Adds a terminal cost penalizing the difference between the final
+    and initial configurations, encouraging the solver to find a
+    steady-state cycle where q_start ~ q_end.
+
+    Parameters
+    ----------
+    urdf_str : str
+        URDF XML string of the model.
+    exercise_name : str
+        Name of the exercise (must be one of the valid exercise names).
+    dt : float
+        Time step for discretization (seconds).
+    n_steps : int
+        Number of time steps in the horizon.
+    periodicity_weight : float
+        Weight on the periodicity (q_start ~ q_end) terminal cost.
+        Higher values enforce stricter cyclic behaviour.
+    use_contacts : bool
+        If True, add bilateral foot-ground contact constraints.
+
+    Returns
+    -------
+    ExerciseOCP
+        Configured cyclic OCP ready for solving.
+    """
+    _require_crocoddyl()
+    _validate_exercise_name(exercise_name)
+    require_positive(dt, "dt")
+    require_positive(float(n_steps), "n_steps")
+    require_positive(periodicity_weight, "periodicity_weight")
+
+    model = pin.buildModelFromXML(urdf_str, pin.JointModelFreeFlyer())
+    state = crocoddyl.StateMultibody(model)
+    actuation = crocoddyl.ActuationModelFloatingBase(state)
+
+    # Running cost: effort regularization + state regularization
+    running_cost_model = crocoddyl.CostModelSum(state)
+    u_residual = crocoddyl.ResidualModelControl(state)
+    u_cost = crocoddyl.CostModelResidual(state, u_residual)
+    running_cost_model.addCost("effort", u_cost, 1e-3)
+
+    x_residual = crocoddyl.ResidualModelState(state)
+    x_cost = crocoddyl.CostModelResidual(state, x_residual)
+    running_cost_model.addCost("state_reg", x_cost, 1e-1)
+
+    # Terminal cost: state regularization + periodicity
+    terminal_cost_model = crocoddyl.CostModelSum(state)
+    terminal_cost_model.addCost("state_reg", x_cost, 1.0)
+
+    # Periodicity constraint: penalize (x_terminal - x_initial)
+    # Uses the state residual targeting x0, weighted heavily
+    x0 = np.concatenate([pin.neutral(model), np.zeros(model.nv)])
+    x_ref_residual = crocoddyl.ResidualModelState(state, x0)
+    x_ref_cost = crocoddyl.CostModelResidual(state, x_ref_residual)
+    terminal_cost_model.addCost("periodicity", x_ref_cost, periodicity_weight)
+
+    # Optionally add contact constraints
+    contacts = None
+    if use_contacts:
+        foot_frames = ["foot_l", "foot_r"]
+        contacts = _build_contact_models(model, state, foot_frames)
+
+        for fname in foot_frames:
+            frame_id = model.getFrameId(fname)
+            cone = crocoddyl.FrictionCone(
+                np.eye(3),
+                0.8,
+                4,
+                False,
+            )
+            friction_residual = crocoddyl.ResidualModelContactFrictionCone(
+                state, frame_id, cone, model.nv
+            )
+            friction_cost = crocoddyl.CostModelResidual(state, friction_residual)
+            running_cost_model.addCost(f"{fname}_friction", friction_cost, 1e-2)
+
+    # Differential action models
+    if contacts is not None:
+        running_dam = crocoddyl.DifferentialActionModelContactFwdDynamics(
+            state, actuation, contacts, running_cost_model
+        )
+        terminal_dam = crocoddyl.DifferentialActionModelContactFwdDynamics(
+            state, actuation, contacts, terminal_cost_model
+        )
+    else:
+        running_dam = crocoddyl.DifferentialActionModelFreeFwdDynamics(
+            state, actuation, running_cost_model
+        )
+        terminal_dam = crocoddyl.DifferentialActionModelFreeFwdDynamics(
+            state, actuation, terminal_cost_model
+        )
+
+    # Integrated action models
+    running_models = [
+        crocoddyl.IntegratedActionModelEuler(running_dam, dt) for _ in range(n_steps)
+    ]
+    terminal_model = crocoddyl.IntegratedActionModelEuler(terminal_dam, 0.0)
+
+    # Shooting problem
     problem = crocoddyl.ShootingProblem(x0, running_models, terminal_model)
 
     return ExerciseOCP(

--- a/src/pinocchio_models/exercises/gait/__init__.py
+++ b/src/pinocchio_models/exercises/gait/__init__.py
@@ -1,0 +1,1 @@
+"""Gait (walking) model builder producing URDF XML for Pinocchio."""

--- a/src/pinocchio_models/exercises/gait/gait_model.py
+++ b/src/pinocchio_models/exercises/gait/gait_model.py
@@ -1,0 +1,80 @@
+"""Gait (walking) model builder (URDF for Pinocchio).
+
+No barbell — the model represents unloaded bipedal walking. The initial
+pose places the model in a natural standing position with slight knee
+flexion (mid-stance ready).
+
+Biomechanical notes:
+- Primary movers: hip flexors/extensors, quadriceps, hamstrings,
+  gastrocnemius/soleus, tibialis anterior
+- The gait cycle is divided into 8 phases from heel strike through
+  swing to the next heel strike
+- Balance mode is alternating single-leg stance
+"""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+
+from pinocchio_models.exercises.base import ExerciseConfig, ExerciseModelBuilder
+from pinocchio_models.shared.constants import (
+    GAIT_ANKLE_ANGLE,
+    GAIT_HIP_ANGLE,
+    GAIT_KNEE_ANGLE,
+)
+from pinocchio_models.shared.utils.urdf_helpers import set_joint_default
+
+
+class GaitModelBuilder(ExerciseModelBuilder):
+    """Builds a bipedal walking URDF model for Pinocchio.
+
+    No barbell is attached — this is an unloaded gait model. The
+    ``attach_barbell`` method is overridden to be a no-op, and the
+    ``build`` method is overridden to skip barbell creation entirely.
+    """
+
+    def __init__(self, config: ExerciseConfig | None = None) -> None:
+        super().__init__(config)
+
+    @property
+    def exercise_name(self) -> str:
+        return "gait"
+
+    def attach_barbell(
+        self,
+        robot: ET.Element,
+        body_links: dict[str, ET.Element],
+        barbell_links: dict[str, ET.Element],
+    ) -> None:
+        """No barbell for gait — intentional no-op."""
+
+    def set_initial_pose(self, robot: ET.Element) -> None:
+        """Set natural standing pose with slight knee flexion.
+
+        Represents the mid-stance ready position before the first
+        heel strike.
+        """
+        set_joint_default(robot, "hip", GAIT_HIP_ANGLE, exact_suffix="_flex")
+        set_joint_default(robot, "knee", GAIT_KNEE_ANGLE)
+        set_joint_default(robot, "ankle", GAIT_ANKLE_ANGLE, exact_suffix="_flex")
+
+
+def build_gait_model(
+    body_mass: float = 70.0,
+    height: float = 1.75,
+    plate_mass_per_side: float = 0.0,
+) -> str:
+    """Convenience function to build a gait model URDF string.
+
+    Default: 70 kg person, 1.75 m tall, no external load.
+    The plate_mass_per_side parameter is accepted for CLI compatibility
+    but ignored (gait has no barbell).
+    """
+    from pinocchio_models.shared.barbell import BarbellSpec
+    from pinocchio_models.shared.body import BodyModelSpec
+
+    config = ExerciseConfig(
+        body_spec=BodyModelSpec(total_mass=body_mass, height=height),
+        barbell_spec=BarbellSpec.mens_olympic(plate_mass_per_side=0.0),
+    )
+    return GaitModelBuilder(config).build()

--- a/src/pinocchio_models/exercises/sit_to_stand/__init__.py
+++ b/src/pinocchio_models/exercises/sit_to_stand/__init__.py
@@ -1,0 +1,1 @@
+"""Sit-to-stand model builder producing URDF XML for Pinocchio."""

--- a/src/pinocchio_models/exercises/sit_to_stand/sit_to_stand_model.py
+++ b/src/pinocchio_models/exercises/sit_to_stand/sit_to_stand_model.py
@@ -1,0 +1,107 @@
+"""Sit-to-stand model builder (URDF for Pinocchio).
+
+Models the transition from seated (on a chair) to standing. A fixed
+"chair" body is added to the URDF as an environmental constraint.
+No barbell is used.
+
+Biomechanical notes:
+- Primary movers: quadriceps, gluteus maximus, hamstrings, erector spinae
+- The sit-to-stand movement is divided into 6 phases: seated, weight
+  shift, seat-off, momentum transfer, extension, and standing
+- Critical for rehabilitation and geriatric assessment
+"""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+
+from pinocchio_models.exercises.base import ExerciseConfig, ExerciseModelBuilder
+from pinocchio_models.shared.constants import (
+    STS_ANKLE_ANGLE,
+    STS_HIP_ANGLE,
+    STS_KNEE_ANGLE,
+)
+from pinocchio_models.shared.utils.urdf_helpers import (
+    add_fixed_joint,
+    add_link,
+    set_joint_default,
+)
+
+# Chair seat height in meters (standard chair height ~0.45 m)
+_CHAIR_SEAT_HEIGHT_M: float = 0.45
+
+# Chair seat depth (front-to-back) in meters
+_CHAIR_SEAT_DEPTH_M: float = 0.40
+
+
+class SitToStandModelBuilder(ExerciseModelBuilder):
+    """Builds a sit-to-stand URDF model for Pinocchio.
+
+    Adds a fixed chair body to the environment and sets the initial
+    pose to a seated position. No barbell is attached.
+    """
+
+    def __init__(self, config: ExerciseConfig | None = None) -> None:
+        super().__init__(config)
+
+    @property
+    def exercise_name(self) -> str:
+        return "sit_to_stand"
+
+    def attach_barbell(
+        self,
+        robot: ET.Element,
+        body_links: dict[str, ET.Element],
+        barbell_links: dict[str, ET.Element],
+    ) -> None:
+        """No barbell for sit-to-stand — add chair body instead."""
+        # Add a chair seat as a fixed environmental body
+        add_link(
+            robot,
+            name="chair_seat",
+            mass=5.0,
+            origin_xyz=(0, 0, 0),
+            ixx=0.01,
+            iyy=0.01,
+            izz=0.01,
+        )
+        # Attach chair to the world via a fixed joint at seat height
+        # The chair is positioned behind and below the pelvis
+        add_fixed_joint(
+            robot,
+            name="chair_to_world",
+            parent="pelvis",
+            child="chair_seat",
+            origin_xyz=(-_CHAIR_SEAT_DEPTH_M / 2, 0, -_CHAIR_SEAT_HEIGHT_M),
+        )
+
+    def set_initial_pose(self, robot: ET.Element) -> None:
+        """Set seated initial pose.
+
+        Hips and knees flexed to approximately 90 degrees,
+        representing a person seated on a standard-height chair.
+        """
+        set_joint_default(robot, "hip", STS_HIP_ANGLE, exact_suffix="_flex")
+        set_joint_default(robot, "knee", STS_KNEE_ANGLE)
+        set_joint_default(robot, "ankle", STS_ANKLE_ANGLE, exact_suffix="_flex")
+
+
+def build_sit_to_stand_model(
+    body_mass: float = 70.0,
+    height: float = 1.75,
+    plate_mass_per_side: float = 0.0,
+) -> str:
+    """Convenience function to build a sit-to-stand model URDF string.
+
+    Default: 70 kg person, 1.75 m tall, no external load.
+    The plate_mass_per_side parameter is accepted for CLI compatibility
+    but ignored (sit-to-stand has no barbell).
+    """
+    from pinocchio_models.shared.barbell import BarbellSpec
+    from pinocchio_models.shared.body import BodyModelSpec
+
+    config = ExerciseConfig(
+        body_spec=BodyModelSpec(total_mass=body_mass, height=height),
+        barbell_spec=BarbellSpec.mens_olympic(plate_mass_per_side=0.0),
+    )
+    return SitToStandModelBuilder(config).build()

--- a/src/pinocchio_models/optimization/exercise_objectives.py
+++ b/src/pinocchio_models/optimization/exercise_objectives.py
@@ -408,6 +408,218 @@ CLEAN_AND_JERK_OBJECTIVE = ExerciseObjective(
 )
 
 # ---------------------------------------------------------------------------
+# Gait (8 phases — full gait cycle from heel strike to heel strike)
+# ---------------------------------------------------------------------------
+GAIT_OBJECTIVE = ExerciseObjective(
+    name="gait",
+    start_pose={
+        "hip_l_flex": _rad(30),
+        "hip_r_flex": _rad(-10),
+        "knee_l_flex": 0.0,
+        "knee_r_flex": _rad(-40),
+        "ankle_l_flex": _rad(-15),
+        "ankle_r_flex": _rad(-20),
+    },
+    end_pose={
+        "hip_l_flex": _rad(30),
+        "hip_r_flex": _rad(-10),
+        "knee_l_flex": 0.0,
+        "knee_r_flex": _rad(-40),
+        "ankle_l_flex": _rad(-15),
+        "ankle_r_flex": _rad(-20),
+    },
+    phases=(
+        Phase(
+            "heel_strike",
+            0.0,
+            {
+                "hip_l_flex": _rad(30),
+                "knee_l_flex": 0.0,
+                "ankle_l_flex": _rad(-15),
+                "hip_r_flex": _rad(-10),
+                "knee_r_flex": _rad(-40),
+                "ankle_r_flex": _rad(-20),
+            },
+        ),
+        Phase(
+            "loading_response",
+            0.12,
+            {
+                "hip_l_flex": _rad(25),
+                "knee_l_flex": _rad(-15),
+                "ankle_l_flex": _rad(-10),
+                "hip_r_flex": _rad(-10),
+                "knee_r_flex": _rad(-40),
+                "ankle_r_flex": _rad(-25),
+            },
+        ),
+        Phase(
+            "mid_stance",
+            0.30,
+            {
+                "hip_l_flex": _rad(5),
+                "knee_l_flex": _rad(-5),
+                "ankle_l_flex": _rad(10),
+                "hip_r_flex": _rad(5),
+                "knee_r_flex": _rad(-5),
+                "ankle_r_flex": 0.0,
+            },
+        ),
+        Phase(
+            "terminal_stance",
+            0.50,
+            {
+                "hip_l_flex": _rad(-10),
+                "knee_l_flex": 0.0,
+                "ankle_l_flex": _rad(15),
+                "hip_r_flex": _rad(20),
+                "knee_r_flex": 0.0,
+                "ankle_r_flex": _rad(-5),
+            },
+        ),
+        Phase(
+            "pre_swing",
+            0.62,
+            {
+                "hip_l_flex": _rad(-10),
+                "knee_l_flex": _rad(-40),
+                "ankle_l_flex": _rad(-20),
+                "hip_r_flex": _rad(30),
+                "knee_r_flex": 0.0,
+                "ankle_r_flex": _rad(-15),
+            },
+        ),
+        Phase(
+            "initial_swing",
+            0.75,
+            {
+                "hip_l_flex": _rad(15),
+                "knee_l_flex": _rad(-60),
+                "ankle_l_flex": _rad(-5),
+                "hip_r_flex": _rad(25),
+                "knee_r_flex": _rad(-15),
+                "ankle_r_flex": _rad(-10),
+            },
+        ),
+        Phase(
+            "mid_swing",
+            0.87,
+            {
+                "hip_l_flex": _rad(25),
+                "knee_l_flex": _rad(-30),
+                "ankle_l_flex": 0.0,
+                "hip_r_flex": _rad(5),
+                "knee_r_flex": _rad(-5),
+                "ankle_r_flex": _rad(10),
+            },
+        ),
+        Phase(
+            "terminal_swing",
+            1.0,
+            {
+                "hip_l_flex": _rad(30),
+                "knee_l_flex": 0.0,
+                "ankle_l_flex": _rad(-15),
+                "hip_r_flex": _rad(-10),
+                "knee_r_flex": _rad(-40),
+                "ankle_r_flex": _rad(-20),
+            },
+        ),
+    ),
+    bar_path_constraint="vertical",
+    balance_mode="bilateral_stance",
+)
+
+# ---------------------------------------------------------------------------
+# Sit-to-Stand (6 phases)
+# ---------------------------------------------------------------------------
+SIT_TO_STAND_OBJECTIVE = ExerciseObjective(
+    name="sit_to_stand",
+    start_pose={
+        "hip_l_flex": _rad(90),
+        "hip_r_flex": _rad(90),
+        "knee_l_flex": _rad(-90),
+        "knee_r_flex": _rad(-90),
+        "ankle_l_flex": _rad(15),
+        "ankle_r_flex": _rad(15),
+        "lumbar_flex": _rad(10),
+    },
+    end_pose={
+        "hip_l_flex": 0.0,
+        "hip_r_flex": 0.0,
+        "knee_l_flex": 0.0,
+        "knee_r_flex": 0.0,
+        "ankle_l_flex": 0.0,
+        "ankle_r_flex": 0.0,
+        "lumbar_flex": 0.0,
+    },
+    phases=(
+        Phase(
+            "seated",
+            0.0,
+            {
+                "hip_l_flex": _rad(90),
+                "knee_l_flex": _rad(-90),
+                "ankle_l_flex": _rad(15),
+                "lumbar_flex": _rad(10),
+            },
+        ),
+        Phase(
+            "weight_shift",
+            0.15,
+            {
+                "hip_l_flex": _rad(100),
+                "knee_l_flex": _rad(-85),
+                "ankle_l_flex": _rad(20),
+                "lumbar_flex": _rad(30),
+            },
+        ),
+        Phase(
+            "seat_off",
+            0.35,
+            {
+                "hip_l_flex": _rad(80),
+                "knee_l_flex": _rad(-80),
+                "ankle_l_flex": _rad(20),
+                "lumbar_flex": _rad(25),
+            },
+        ),
+        Phase(
+            "momentum_transfer",
+            0.55,
+            {
+                "hip_l_flex": _rad(50),
+                "knee_l_flex": _rad(-50),
+                "ankle_l_flex": _rad(10),
+                "lumbar_flex": _rad(15),
+            },
+        ),
+        Phase(
+            "extension",
+            0.80,
+            {
+                "hip_l_flex": _rad(20),
+                "knee_l_flex": _rad(-20),
+                "ankle_l_flex": _rad(5),
+                "lumbar_flex": _rad(5),
+            },
+        ),
+        Phase(
+            "standing",
+            1.0,
+            {
+                "hip_l_flex": 0.0,
+                "knee_l_flex": 0.0,
+                "ankle_l_flex": 0.0,
+                "lumbar_flex": 0.0,
+            },
+        ),
+    ),
+    bar_path_constraint="vertical",
+    balance_mode="bilateral_stance",
+)
+
+# ---------------------------------------------------------------------------
 # Registry
 # ---------------------------------------------------------------------------
 EXERCISE_OBJECTIVES: dict[str, ExerciseObjective] = {
@@ -416,6 +628,8 @@ EXERCISE_OBJECTIVES: dict[str, ExerciseObjective] = {
     "bench_press": BENCH_PRESS_OBJECTIVE,
     "snatch": SNATCH_OBJECTIVE,
     "clean_and_jerk": CLEAN_AND_JERK_OBJECTIVE,
+    "gait": GAIT_OBJECTIVE,
+    "sit_to_stand": SIT_TO_STAND_OBJECTIVE,
 }
 
 

--- a/src/pinocchio_models/shared/constants.py
+++ b/src/pinocchio_models/shared/constants.py
@@ -120,6 +120,16 @@ CLEAN_AND_JERK_KNEE_ANGLE: float = -math.radians(65)
 CLEAN_AND_JERK_LUMBAR_ANGLE: float = math.radians(10)
 CLEAN_AND_JERK_ANKLE_ANGLE: float = math.radians(18)  # Dorsiflexion at setup
 
+# Gait: natural standing (mid-stance ready position)
+GAIT_HIP_ANGLE: float = math.radians(5)  # Slight flexion
+GAIT_KNEE_ANGLE: float = -math.radians(5)  # Slight flexion
+GAIT_ANKLE_ANGLE: float = 0.0  # Neutral
+
+# Sit-to-stand: seated position (~90 deg hip/knee flexion)
+STS_HIP_ANGLE: float = math.radians(90)
+STS_KNEE_ANGLE: float = -math.radians(90)
+STS_ANKLE_ANGLE: float = math.radians(15)  # Slight dorsiflexion
+
 # --- Grip width fractions (fraction of shaft length from center) ---
 BENCH_PRESS_GRIP_FRACTION: float = 0.3
 DEADLIFT_GRIP_FRACTION: float = 0.3
@@ -134,6 +144,8 @@ VALID_EXERCISE_NAMES: frozenset[str] = frozenset(
         "deadlift",
         "snatch",
         "clean_and_jerk",
+        "gait",
+        "sit_to_stand",
     }
 )
 

--- a/src/pinocchio_models/shared/parity/standard.py
+++ b/src/pinocchio_models/shared/parity/standard.py
@@ -80,6 +80,8 @@ EXERCISE_PHASE_COUNTS = {
     "bench_press": 5,
     "snatch": 6,
     "clean_and_jerk": 8,
+    "gait": 8,
+    "sit_to_stand": 6,
 }
 
 GRAVITY = (0.0, 0.0, -9.80665)

--- a/tests/unit/addons/test_crocoddyl_oc.py
+++ b/tests/unit/addons/test_crocoddyl_oc.py
@@ -41,6 +41,32 @@ class TestCrocoddylOCImportGuard:
                 oc_mod.extract_joint_torques(([], []), None)  # type: ignore
 
 
+class TestCyclicOCPImportGuard:
+    def test_cyclic_ocp_raises_without_crocoddyl(self) -> None:
+        with patch.dict("sys.modules", {"crocoddyl": None, "pinocchio": None}):
+            import importlib
+
+            import pinocchio_models.addons.crocoddyl.optimal_control as oc_mod
+
+            importlib.reload(oc_mod)
+
+            with pytest.raises(ImportError, match="Crocoddyl is not installed"):
+                oc_mod.create_cyclic_ocp("<robot/>", "gait")
+
+    def test_cyclic_ocp_validates_exercise_name(self) -> None:
+        with patch.dict("sys.modules", {"crocoddyl": None, "pinocchio": None}):
+            import importlib
+
+            import pinocchio_models.addons.crocoddyl.optimal_control as oc_mod
+
+            importlib.reload(oc_mod)
+
+            # Import guard fires before validation, but validation
+            # function can be tested directly
+            with pytest.raises(ValueError, match="Unknown exercise"):
+                oc_mod._validate_exercise_name("not_a_real_exercise")
+
+
 class TestExerciseNameValidation:
     def test_rejects_invalid_exercise_name(self) -> None:
         """Validates exercise name even when crocoddyl is missing."""
@@ -65,6 +91,8 @@ class TestExerciseNameValidation:
             "deadlift",
             "snatch",
             "clean_and_jerk",
+            "gait",
+            "sit_to_stand",
         ):
             oc_mod._validate_exercise_name(name)
 

--- a/tests/unit/exercises/test_gait.py
+++ b/tests/unit/exercises/test_gait.py
@@ -1,0 +1,106 @@
+"""Tests for gait (walking) model builder."""
+
+import xml.etree.ElementTree as ET
+
+import pytest
+
+from pinocchio_models.exercises.gait.gait_model import (
+    GaitModelBuilder,
+    build_gait_model,
+)
+from pinocchio_models.shared.constants import (
+    GAIT_ANKLE_ANGLE,
+    GAIT_HIP_ANGLE,
+    GAIT_KNEE_ANGLE,
+)
+
+
+class TestGaitModelBuilder:
+    def test_exercise_name(self) -> None:
+        builder = GaitModelBuilder()
+        assert builder.exercise_name == "gait"
+
+    def test_build_produces_valid_urdf(self) -> None:
+        xml_str = build_gait_model()
+        root = ET.fromstring(xml_str)
+        assert root.tag == "robot"
+        assert root.get("name") == "gait"  # type: ignore
+
+    def test_no_barbell_attached(self) -> None:
+        """Gait model has no barbell attachment joints."""
+        xml_str = build_gait_model()
+        root = ET.fromstring(xml_str)
+        joint_names = {j.get("name") for j in root.findall("joint")}  # type: ignore
+        assert "barbell_to_hand_l" not in joint_names
+        assert "barbell_to_hand_r" not in joint_names
+        assert "barbell_to_torso" not in joint_names
+
+    def test_has_body_links(self) -> None:
+        xml_str = build_gait_model()
+        root = ET.fromstring(xml_str)
+        links = root.findall("link")
+        # Body links should be present (pelvis, torso, legs, arms, etc.)
+        link_names = {link.get("name") for link in links}  # type: ignore
+        assert "pelvis" in link_names
+        assert "torso" in link_names
+
+    def test_initial_pose_hip_defaults(self) -> None:
+        xml_str = build_gait_model()
+        root = ET.fromstring(xml_str)
+        hip_flex_joints = [
+            j
+            for j in root.findall("joint")
+            if j.get("name", "").startswith("hip_")  # type: ignore
+            and j.get("name", "").endswith("_flex")  # type: ignore
+        ]
+        assert len(hip_flex_joints) == 2
+        for j in hip_flex_joints:
+            assert j.get("initial_position") is not None  # type: ignore
+            assert float(j.get("initial_position")) == pytest.approx(  # type: ignore
+                GAIT_HIP_ANGLE, abs=1e-4
+            )
+
+    def test_initial_pose_knee_defaults(self) -> None:
+        xml_str = build_gait_model()
+        root = ET.fromstring(xml_str)
+        knee_joints = [
+            j
+            for j in root.findall("joint")
+            if j.get("name", "").startswith("knee_")  # type: ignore
+        ]
+        for j in knee_joints:
+            assert j.get("initial_position") is not None  # type: ignore
+            assert float(j.get("initial_position")) == pytest.approx(  # type: ignore
+                GAIT_KNEE_ANGLE, abs=1e-4
+            )
+
+    def test_initial_pose_ankle_defaults(self) -> None:
+        xml_str = build_gait_model()
+        root = ET.fromstring(xml_str)
+        ankle_flex_joints = [
+            j
+            for j in root.findall("joint")
+            if j.get("name", "").startswith("ankle_")  # type: ignore
+            and j.get("name", "").endswith("_flex")  # type: ignore
+        ]
+        assert len(ankle_flex_joints) == 2
+        for j in ankle_flex_joints:
+            assert j.get("initial_position") is not None  # type: ignore
+            assert float(j.get("initial_position")) == pytest.approx(  # type: ignore
+                GAIT_ANKLE_ANGLE, abs=1e-4
+            )
+
+    def test_custom_body_parameters(self) -> None:
+        xml_str = build_gait_model(body_mass=65.0, height=1.60)
+        root = ET.fromstring(xml_str)
+        assert root.tag == "robot"
+        assert len(root.findall("link")) >= 20
+
+    def test_hip_angle_within_limits(self) -> None:
+        """Hip initial angle must be within anatomical ROM."""
+        from pinocchio_models.shared.constants import (
+            HIP_FLEXION_MAX,
+            HIP_FLEXION_MIN,
+        )
+
+        assert HIP_FLEXION_MIN <= GAIT_HIP_ANGLE <= HIP_FLEXION_MAX

--- a/tests/unit/exercises/test_sit_to_stand.py
+++ b/tests/unit/exercises/test_sit_to_stand.py
@@ -1,0 +1,116 @@
+"""Tests for sit-to-stand model builder."""
+
+import xml.etree.ElementTree as ET
+
+import pytest
+
+from pinocchio_models.exercises.sit_to_stand.sit_to_stand_model import (
+    SitToStandModelBuilder,
+    build_sit_to_stand_model,
+)
+from pinocchio_models.shared.constants import (
+    STS_ANKLE_ANGLE,
+    STS_HIP_ANGLE,
+    STS_KNEE_ANGLE,
+)
+
+
+class TestSitToStandModelBuilder:
+    def test_exercise_name(self) -> None:
+        builder = SitToStandModelBuilder()
+        assert builder.exercise_name == "sit_to_stand"
+
+    def test_build_produces_valid_urdf(self) -> None:
+        xml_str = build_sit_to_stand_model()
+        root = ET.fromstring(xml_str)
+        assert root.tag == "robot"
+        assert root.get("name") == "sit_to_stand"  # type: ignore
+
+    def test_has_chair_body(self) -> None:
+        """Sit-to-stand model should have a chair_seat link."""
+        xml_str = build_sit_to_stand_model()
+        root = ET.fromstring(xml_str)
+        link_names = {link.get("name") for link in root.findall("link")}  # type: ignore
+        assert "chair_seat" in link_names
+
+    def test_chair_attached_to_pelvis(self) -> None:
+        xml_str = build_sit_to_stand_model()
+        root = ET.fromstring(xml_str)
+        joint_names = {j.get("name") for j in root.findall("joint")}  # type: ignore
+        assert "chair_to_world" in joint_names
+
+    def test_chair_joint_is_fixed(self) -> None:
+        xml_str = build_sit_to_stand_model()
+        root = ET.fromstring(xml_str)
+        for joint in root.findall("joint"):
+            if joint.get("name") == "chair_to_world":
+                assert joint.get("type") == "fixed"  # type: ignore
+
+    def test_no_barbell_hand_attachment(self) -> None:
+        """No barbell-to-hand joints in sit-to-stand."""
+        xml_str = build_sit_to_stand_model()
+        root = ET.fromstring(xml_str)
+        joint_names = {j.get("name") for j in root.findall("joint")}  # type: ignore
+        assert "barbell_to_hand_l" not in joint_names
+        assert "barbell_to_hand_r" not in joint_names
+
+    def test_initial_pose_hip_defaults(self) -> None:
+        xml_str = build_sit_to_stand_model()
+        root = ET.fromstring(xml_str)
+        hip_flex_joints = [
+            j
+            for j in root.findall("joint")
+            if j.get("name", "").startswith("hip_")  # type: ignore
+            and j.get("name", "").endswith("_flex")  # type: ignore
+        ]
+        assert len(hip_flex_joints) == 2
+        for j in hip_flex_joints:
+            assert j.get("initial_position") is not None  # type: ignore
+            assert float(j.get("initial_position")) == pytest.approx(  # type: ignore
+                STS_HIP_ANGLE, abs=1e-4
+            )
+
+    def test_initial_pose_knee_defaults(self) -> None:
+        xml_str = build_sit_to_stand_model()
+        root = ET.fromstring(xml_str)
+        knee_joints = [
+            j
+            for j in root.findall("joint")
+            if j.get("name", "").startswith("knee_")  # type: ignore
+        ]
+        for j in knee_joints:
+            assert j.get("initial_position") is not None  # type: ignore
+            assert float(j.get("initial_position")) == pytest.approx(  # type: ignore
+                STS_KNEE_ANGLE, abs=1e-4
+            )
+
+    def test_initial_pose_ankle_defaults(self) -> None:
+        xml_str = build_sit_to_stand_model()
+        root = ET.fromstring(xml_str)
+        ankle_flex_joints = [
+            j
+            for j in root.findall("joint")
+            if j.get("name", "").startswith("ankle_")  # type: ignore
+            and j.get("name", "").endswith("_flex")  # type: ignore
+        ]
+        assert len(ankle_flex_joints) == 2
+        for j in ankle_flex_joints:
+            assert j.get("initial_position") is not None  # type: ignore
+            assert float(j.get("initial_position")) == pytest.approx(  # type: ignore
+                STS_ANKLE_ANGLE, abs=1e-4
+            )
+
+    def test_custom_body_parameters(self) -> None:
+        xml_str = build_sit_to_stand_model(body_mass=60.0, height=1.65)
+        root = ET.fromstring(xml_str)
+        assert root.tag == "robot"
+        assert len(root.findall("link")) >= 20
+
+    def test_hip_angle_within_limits(self) -> None:
+        """Hip initial angle must be within anatomical ROM."""
+        from pinocchio_models.shared.constants import (
+            HIP_FLEXION_MAX,
+            HIP_FLEXION_MIN,
+        )
+
+        assert HIP_FLEXION_MIN <= STS_HIP_ANGLE <= HIP_FLEXION_MAX

--- a/tests/unit/optimization/test_exercise_objectives.py
+++ b/tests/unit/optimization/test_exercise_objectives.py
@@ -20,6 +20,8 @@ EXPECTED_EXERCISES = [
     "bench_press",
     "snatch",
     "clean_and_jerk",
+    "gait",
+    "sit_to_stand",
 ]
 
 

--- a/tests/unit/shared/test_constants.py
+++ b/tests/unit/shared/test_constants.py
@@ -105,13 +105,15 @@ class TestJointLimitConstants:
 
 
 class TestValidExerciseNames:
-    def test_contains_all_five_exercises(self) -> None:
-        assert len(VALID_EXERCISE_NAMES) == 5
+    def test_contains_all_exercises(self) -> None:
+        assert len(VALID_EXERCISE_NAMES) == 7
         assert "back_squat" in VALID_EXERCISE_NAMES
         assert "bench_press" in VALID_EXERCISE_NAMES
         assert "deadlift" in VALID_EXERCISE_NAMES
         assert "snatch" in VALID_EXERCISE_NAMES
         assert "clean_and_jerk" in VALID_EXERCISE_NAMES
+        assert "gait" in VALID_EXERCISE_NAMES
+        assert "sit_to_stand" in VALID_EXERCISE_NAMES
 
     def test_is_frozen(self) -> None:
         assert isinstance(VALID_EXERCISE_NAMES, frozenset)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -24,7 +24,7 @@ class TestCLI:
             result = main(["all", "--output-dir", tmpdir])
             assert result == 0
             files = list(Path(tmpdir).glob("*.urdf"))
-            assert len(files) == 5
+            assert len(files) == 7
 
     def test_generates_with_custom_parameters(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/unit/test_convenience_imports.py
+++ b/tests/unit/test_convenience_imports.py
@@ -9,6 +9,8 @@ class TestConvenienceImports:
             BenchPressModelBuilder,
             CleanAndJerkModelBuilder,
             DeadliftModelBuilder,
+            GaitModelBuilder,
+            SitToStandModelBuilder,
             SnatchModelBuilder,
             SquatModelBuilder,
         )
@@ -16,6 +18,8 @@ class TestConvenienceImports:
         assert BenchPressModelBuilder is not None
         assert CleanAndJerkModelBuilder is not None
         assert DeadliftModelBuilder is not None
+        assert GaitModelBuilder is not None
+        assert SitToStandModelBuilder is not None
         assert SnatchModelBuilder is not None
         assert SquatModelBuilder is not None
 
@@ -24,6 +28,8 @@ class TestConvenienceImports:
             build_bench_press_model,
             build_clean_and_jerk_model,
             build_deadlift_model,
+            build_gait_model,
+            build_sit_to_stand_model,
             build_snatch_model,
             build_squat_model,
         )
@@ -31,6 +37,8 @@ class TestConvenienceImports:
         assert callable(build_bench_press_model)
         assert callable(build_clean_and_jerk_model)
         assert callable(build_deadlift_model)
+        assert callable(build_gait_model)
+        assert callable(build_sit_to_stand_model)
         assert callable(build_snatch_model)
         assert callable(build_squat_model)
 


### PR DESCRIPTION
## Summary

- **Rust accelerator** (`rust_core/`): PyO3 + Rayon crate with `inverse_dynamics_batch()`, `com_batch()`, and `interpolate_phases_rs()` for parallel batch computation
- **Gait exercise** (`exercises/gait/`): `GaitModelBuilder` with no barbell, walking initial pose, and 8-phase `GAIT_OBJECTIVE` covering heel strike through terminal swing
- **Sit-to-stand exercise** (`exercises/sit_to_stand/`): `SitToStandModelBuilder` with chair body, seated initial pose, and 6-phase `SIT_TO_STAND_OBJECTIVE` (seated → standing)
- **Cyclic OCP** (`addons/crocoddyl/`): `create_cyclic_ocp()` adds periodicity terminal cost (q_start ≈ q_end) for steady-state gait optimization
- Updated CLI, convenience imports, constants, parity standard, and all affected tests

## Test plan

- [x] 380 tests passing (up from ~352), including new gait and sit-to-stand tests
- [x] `ruff check src/ tests/` — zero violations
- [x] `ruff format --check` — all new/modified files formatted
- [ ] Verify `cargo check` in `rust_core/` (requires Rust toolchain)
- [ ] Verify `pinocchio-models gait --output-dir ./models` generates valid URDF
- [ ] Verify `pinocchio-models sit_to_stand --output-dir ./models` generates valid URDF

🤖 Generated with [Claude Code](https://claude.com/claude-code)