### PR TITLE
Replace bare except Exception with specific types

### DIFF
--- a/src/pinocchio_models/addons/pink/ik_solver.py
+++ b/src/pinocchio_models/addons/pink/ik_solver.py
@@ -267,7 +267,7 @@ def compute_exercise_keyframes(
         try:
             root_joint_id = model.getJointId("root_joint")
             freeflyer_nq = model.joints[root_joint_id].nq
-        except Exception as _e:  # noqa: BLE001
+        except (RuntimeError, KeyError) as _e:
             logger.warning("root_joint not found in model, using fallback nq=7: %s", _e)
             freeflyer_nq = 7  # Fallback for standard FreeFlyer
         nq_actuated = model.nq - freeflyer_nq

--- a/src/pinocchio_models/shared/utils/urdf_helpers.py
+++ b/src/pinocchio_models/shared/utils/urdf_helpers.py
@@ -330,7 +330,7 @@ def get_initial_configuration(model: Any, xml_str: str) -> Any:
         joint_name = joint_el.get("name", "")
         try:
             joint_id = model.getJointId(joint_name)
-        except Exception as _e:  # noqa: BLE001
+        except (RuntimeError, KeyError) as _e:
             logger.warning("Joint %s not found in model: %s", joint_name, _e)
             continue
         if joint_id >= len(model.joints):


### PR DESCRIPTION
## Summary
- Narrowed `except Exception` in `ik_solver.py` (line 270) and `urdf_helpers.py` (line 333) to `except (RuntimeError, KeyError)` -- the actual exceptions pinocchio's C++ bindings raise on joint lookup failures
- Removed the `# noqa: BLE001` suppression comments that were masking the ruff lint violation

Closes #59

## Test plan
- [x] All existing tests pass (`pytest --tb=short -q`)
- [x] `ruff check` passes on both changed files with no warnings
- [x] Confirmed no remaining `except Exception` clauses in `src/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)