### PR TITLE
Fix lumbar flexion max: 45° -> 60° for floor pulls

### DIFF
--- a/src/pinocchio_models/shared/constants.py
+++ b/src/pinocchio_models/shared/constants.py
@@ -18,7 +18,9 @@ import math
 # Lumbar spine (flexion/extension about X-axis)
 # Kapandji (2008) cites ~20-35 deg extension; deadlift lockout requires >10 deg.
 LUMBAR_FLEXION_MIN: float = math.radians(-25)  # Extension ~25 deg
-LUMBAR_FLEXION_MAX: float = math.radians(60)  # Flexion ~60 deg (floor pulls require >45°; fixes #63)
+LUMBAR_FLEXION_MAX: float = math.radians(
+    60
+)  # Flexion ~60 deg (floor pulls require >45°; fixes #63)
 
 # Lumbar lateral bending (about Z-axis) -- Kapandji (2008)
 # ~20 deg each side

--- a/src/pinocchio_models/shared/constants.py
+++ b/src/pinocchio_models/shared/constants.py
@@ -18,7 +18,7 @@ import math
 # Lumbar spine (flexion/extension about X-axis)
 # Kapandji (2008) cites ~20-35 deg extension; deadlift lockout requires >10 deg.
 LUMBAR_FLEXION_MIN: float = math.radians(-25)  # Extension ~25 deg
-LUMBAR_FLEXION_MAX: float = math.radians(45)  # Flexion ~45 deg
+LUMBAR_FLEXION_MAX: float = math.radians(60)  # Flexion ~60 deg (floor pulls require >45°; fixes #63)
 
 # Lumbar lateral bending (about Z-axis) -- Kapandji (2008)
 # ~20 deg each side


### PR DESCRIPTION
## Summary
- Increases `LUMBAR_FLEXION_MAX` from `math.radians(45)` to `math.radians(60)` in `src/pinocchio_models/shared/constants.py`
- 45 degrees was too restrictive for deadlift and other floor-pull setup positions
- 60 degrees aligns with Kapandji (2008) lumbar flexion ROM and permits correct floor-pull postures

## Cross-repo parity
Drake_Models, MuJoCo_Models, and OpenSim_Models all currently use 45 degrees in their parity standards. Those repos will need matching PRs to update to 60 degrees for full cross-repo parity.

## Test plan
- [x] All existing unit and integration tests pass (404 passed, 1 pre-existing env failure in geometry_hypothesis unrelated to this change)
- [x] `test_constants.py` lower < upper checks pass with new value
- [x] Parity standard references `LUMBAR_FLEXION_MAX` by name, so it picks up the new value automatically

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)