### PR TITLE
fix: correct deadlift docstring lumbar extension -> flexion

### DIFF
--- a/src/pinocchio_models/exercises/deadlift/deadlift_model.py
+++ b/src/pinocchio_models/exercises/deadlift/deadlift_model.py
@@ -45,7 +45,7 @@ class DeadliftModelBuilder(ExerciseModelBuilder):
     def set_initial_pose(self, robot: ET.Element) -> None:
         """Set starting position: hip-hinged, bar on ground.
 
-        Hips flexed ~80 deg, knees ~60 deg, slight lumbar extension.
+        Hips flexed ~80 deg, knees ~60 deg, slight lumbar flexion.
 
         Note: ``initial_position`` XML attributes are metadata only —
         Pinocchio does not read them at load time.  Use


### PR DESCRIPTION
## Summary
- Fixes docstring in `deadlift_model.py` that incorrectly says "slight lumbar extension" when `DEADLIFT_LUMBAR_ANGLE = math.radians(10)` is a positive value representing 10 degrees of **flexion**

Closes #64

## Test plan
- [ ] Docstring-only change; no functional impact
- [ ] CI tests should pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)