### PR TITLE
fix: add __post_init__ validation to TrajectoryConfig

### DIFF
--- a/src/pinocchio_models/optimization/trajectory_optimizer.py
+++ b/src/pinocchio_models/optimization/trajectory_optimizer.py
@@ -9,9 +9,27 @@ import numpy as np
 from pinocchio_models.optimization.exercise_objectives import ExerciseObjective
 
 
+def _validate_non_negative_weight(name: str, value: float) -> None:
+    """Validate that a weight is non-negative."""
+    if value < 0.0:
+        msg = f"{name} must be non-negative, got {value}"
+        raise ValueError(msg)
+
+
 @dataclass(frozen=True)
 class TrajectoryConfig:
-    """Parameters controlling the trajectory optimisation loop."""
+    """Parameters controlling the trajectory optimisation loop.
+
+    Attributes:
+        n_timesteps: Number of discrete time steps in trajectory.
+        dt: Time step duration in seconds.
+        max_iterations: Maximum optimiser iterations before stopping.
+        convergence_tol: Cost change threshold for convergence.
+        control_weight: Penalty weight on joint torque magnitudes.
+        state_weight: Weight for tracking target trajectory.
+        terminal_weight: Weight for reaching the final target pose.
+        balance_weight: Weight for keeping CoM over base of support.
+    """
 
     n_timesteps: int = 100
     dt: float = 0.01
@@ -21,6 +39,25 @@ class TrajectoryConfig:
     state_weight: float = 1.0
     terminal_weight: float = 10.0
     balance_weight: float = 5.0
+
+    def __post_init__(self) -> None:
+        """Validate configuration values are physically plausible."""
+        if self.n_timesteps < 1:
+            msg = f"n_timesteps must be >= 1, got {self.n_timesteps}"
+            raise ValueError(msg)
+        if self.dt <= 0.0:
+            msg = f"dt must be positive, got {self.dt}"
+            raise ValueError(msg)
+        if self.max_iterations < 1:
+            msg = f"max_iterations must be >= 1, got {self.max_iterations}"
+            raise ValueError(msg)
+        if self.convergence_tol <= 0.0:
+            msg = f"convergence_tol must be positive, got {self.convergence_tol}"
+            raise ValueError(msg)
+        _validate_non_negative_weight("control_weight", self.control_weight)
+        _validate_non_negative_weight("state_weight", self.state_weight)
+        _validate_non_negative_weight("terminal_weight", self.terminal_weight)
+        _validate_non_negative_weight("balance_weight", self.balance_weight)
 
 
 @dataclass

--- a/tests/unit/optimization/test_exercise_objectives.py
+++ b/tests/unit/optimization/test_exercise_objectives.py
@@ -137,6 +137,74 @@ class TestTrajectoryConfig:
         assert cfg.terminal_weight == 10.0
         assert cfg.balance_weight == 5.0
 
+    # ------------------------------------------------------------------
+    # __post_init__ validation – positive integer fields
+    # ------------------------------------------------------------------
+    @pytest.mark.parametrize("n_timesteps", [0, -1, -100])
+    def test_invalid_n_timesteps_raises(self, n_timesteps: int) -> None:
+        with pytest.raises(ValueError, match="n_timesteps"):
+            TrajectoryConfig(n_timesteps=n_timesteps)
+
+    @pytest.mark.parametrize("max_iterations", [0, -1, -50])
+    def test_invalid_max_iterations_raises(self, max_iterations: int) -> None:
+        with pytest.raises(ValueError, match="max_iterations"):
+            TrajectoryConfig(max_iterations=max_iterations)
+
+    # ------------------------------------------------------------------
+    # __post_init__ validation – positive float fields
+    # ------------------------------------------------------------------
+    @pytest.mark.parametrize("dt", [0.0, -0.001, -1.0])
+    def test_invalid_dt_raises(self, dt: float) -> None:
+        with pytest.raises(ValueError, match="dt"):
+            TrajectoryConfig(dt=dt)
+
+    @pytest.mark.parametrize("convergence_tol", [0.0, -1e-5, -1.0])
+    def test_invalid_convergence_tol_raises(self, convergence_tol: float) -> None:
+        with pytest.raises(ValueError, match="convergence_tol"):
+            TrajectoryConfig(convergence_tol=convergence_tol)
+
+    # ------------------------------------------------------------------
+    # __post_init__ validation – non-negative weight fields
+    # ------------------------------------------------------------------
+    @pytest.mark.parametrize(
+        "field,value",
+        [
+            ("control_weight", -1e-3),
+            ("state_weight", -1.0),
+            ("terminal_weight", -10.0),
+            ("balance_weight", -5.0),
+        ],
+    )
+    def test_negative_weight_raises(self, field: str, value: float) -> None:
+        with pytest.raises(ValueError, match=field):
+            TrajectoryConfig(**{field: value})
+
+    # Zero weights are allowed (disabling a cost term is valid)
+    @pytest.mark.parametrize(
+        "field",
+        ["control_weight", "state_weight", "terminal_weight", "balance_weight"],
+    )
+    def test_zero_weight_accepted(self, field: str) -> None:
+        cfg = TrajectoryConfig(**{field: 0.0})
+        assert getattr(cfg, field) == 0.0
+
+    # Minimum valid values for strictly-positive fields
+    def test_minimum_valid_n_timesteps(self) -> None:
+        cfg = TrajectoryConfig(n_timesteps=1)
+        assert cfg.n_timesteps == 1
+
+    def test_minimum_valid_max_iterations(self) -> None:
+        cfg = TrajectoryConfig(max_iterations=1)
+        assert cfg.max_iterations == 1
+
+    def test_minimum_valid_dt(self) -> None:
+        cfg = TrajectoryConfig(dt=1e-9)
+        assert cfg.dt == pytest.approx(1e-9)
+
+    def test_minimum_valid_convergence_tol(self) -> None:
+        cfg = TrajectoryConfig(convergence_tol=1e-12)
+        assert cfg.convergence_tol == pytest.approx(1e-12)
+
 
 class TestTrajectoryResult:
     def test_creation(self) -> None:


### PR DESCRIPTION
Closes #103

## Summary
- Add `__post_init__` to `TrajectoryConfig` validating all fields (matching MuJoCo's equivalent at `trajectory_optimizer.py:48-66`)
- Extract `_validate_non_negative_weight` helper for weight fields
- Add tests verifying invalid configs raise `ValueError` with clear messages

## Test plan
- [x] Existing tests still pass
- [x] Invalid configs are rejected with clear error messages