### PR TITLE
docs: document intentional cross-repo duplication in preconditions.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2026-03-30
+## [Unreleased] - 2026-03-31
+
+### Documented (cross-repo duplication — issue #104)
+
+- **DRY**: Added header comment to `preconditions.py` documenting that the six
+  core `require_*` functions are intentionally duplicated across
+  Pinocchio_Models, MuJoCo_Models, and OpenSim_Models, and pointing to issue
+  #104 for migration options if a shared package is ever warranted.
 
 ### Fixed (A-N Assessment Remediation — issue #100)
 

--- a/src/pinocchio_models/shared/contracts/preconditions.py
+++ b/src/pinocchio_models/shared/contracts/preconditions.py
@@ -1,3 +1,11 @@
+# NOTE: The six core require_* functions in this module (require_positive,
+# require_non_negative, require_unit_vector, require_finite, require_in_range,
+# require_shape) are duplicated verbatim across Pinocchio_Models, MuJoCo_Models,
+# and OpenSim_Models.  The duplication is intentional: each repo is an
+# independent deployable and a cross-repo shared package adds coordination
+# overhead that is not yet warranted.  If that changes, see
+# D-sorganization/Pinocchio_Models#104 for context and migration options.
+
 """Design-by-Contract precondition checks.
 
 All public functions in this project validate inputs via these guards.


### PR DESCRIPTION
## Summary

- Adds a 7-line header comment to `src/pinocchio_models/shared/contracts/preconditions.py` explaining that the six core `require_*` functions are intentionally duplicated verbatim across Pinocchio_Models, MuJoCo_Models, and OpenSim_Models.
- The comment cites issue #104 so future maintainers can find migration options if a shared package ever becomes warranted.
- Updates `CHANGELOG.md` date to 2026-03-31 and records the change under a new `Documented` section.

Closes #104.

## Decision rationale

The issue offered two options: git submodule / shared package, or accept duplication with a comment. A cross-repo package introduces release-coordination overhead (versioning, publish pipeline, three-repo update PRs) that is not yet justified for 53 lines of stable utility code. Documenting the known duplication with a traceable comment is the lower-risk approach and fully resolves the issue.

## Test plan

- [x] `ruff check src tests` — zero violations
- [x] `ruff format --check src tests` — zero diffs
- [x] `mypy src` — no errors (55 source files)
- [x] Pre-existing flaky test (`test_orthogonality_x`) confirmed to pass in isolation; unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)