### PR TITLE
feat: add DbC contracts to Crocoddyl and Pink IK wrappers

### DIFF
--- a/src/pinocchio_models/addons/crocoddyl/optimal_control.py
+++ b/src/pinocchio_models/addons/crocoddyl/optimal_control.py
@@ -352,6 +352,11 @@ def solve_trajectory(
     _require_crocoddyl()
 
     if initial_state is not None:
+        if not np.all(np.isfinite(initial_state)):
+            raise ValueError(
+                "initial_state contains non-finite values (NaN or Inf). "
+                "Provide a valid finite state vector."
+            )
         ocp.problem.x0 = initial_state
 
     solver = crocoddyl.SolverDDP(ocp.problem)

--- a/src/pinocchio_models/addons/pink/ik_solver.py
+++ b/src/pinocchio_models/addons/pink/ik_solver.py
@@ -11,6 +11,7 @@ Usage requires the optional ``pink`` extra::
 from __future__ import annotations
 
 import logging
+import warnings
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -211,6 +212,18 @@ def solve_pose(
     _require_pink()
     require_positive(float(max_iterations), "max_iterations")
 
+    for frame_name, pose in targets.items():
+        pose_arr = np.asarray(pose)
+        if pose_arr.shape != (4, 4):
+            raise ValueError(
+                f"SE(3) pose for frame '{frame_name}' must be a (4, 4) matrix, "
+                f"got shape {pose_arr.shape}"
+            )
+        if not np.all(np.isfinite(pose_arr)):
+            raise ValueError(
+                f"SE(3) pose for frame '{frame_name}' contains non-finite values"
+            )
+
     model = problem.model
     data = problem.data
 
@@ -222,10 +235,21 @@ def solve_pose(
     configuration = pink.Configuration(model, data, pin.neutral(model))
 
     # --- Solve phase ---
+    converged = False
     for _iteration in range(max_iterations):
         configuration = _ik_step(configuration, model, data, tasks)
         if _check_convergence(configuration, tasks, tolerance):
+            converged = True
             break
+
+    if not converged:
+        warnings.warn(
+            f"IK did not converge within {max_iterations} iterations "
+            f"(tolerance={tolerance}). The returned configuration may not satisfy "
+            "all target constraints.",
+            UserWarning,
+            stacklevel=2,
+        )
 
     return configuration.q
 

--- a/tests/unit/addons/test_crocoddyl_oc.py
+++ b/tests/unit/addons/test_crocoddyl_oc.py
@@ -108,3 +108,63 @@ class TestExtractJointTorques:
             np.testing.assert_array_equal(result, np.array(controls))
         finally:
             oc_mod._HAS_CROCODDYL = original
+
+
+class TestSolveTrajectoryDbCContracts:
+    """DbC contracts for solve_trajectory (issue #124)."""
+
+    def test_rejects_non_finite_initial_state(self) -> None:
+        """initial_state must be finite."""
+        import pinocchio_models.addons.crocoddyl.optimal_control as oc_mod
+
+        original = oc_mod._HAS_CROCODDYL
+        oc_mod._HAS_CROCODDYL = True
+        try:
+            mock_ocp = MagicMock()
+            bad_state = np.array([float("nan"), 1.0, 2.0])
+            with pytest.raises(ValueError, match="initial_state.*non-finite"):
+                oc_mod.solve_trajectory(mock_ocp, initial_state=bad_state)
+        finally:
+            oc_mod._HAS_CROCODDYL = original
+
+    def test_rejects_inf_initial_state(self) -> None:
+        """initial_state must not contain Inf."""
+        import pinocchio_models.addons.crocoddyl.optimal_control as oc_mod
+
+        original = oc_mod._HAS_CROCODDYL
+        oc_mod._HAS_CROCODDYL = True
+        try:
+            mock_ocp = MagicMock()
+            bad_state = np.array([float("inf"), 1.0, 2.0])
+            with pytest.raises(ValueError, match="initial_state.*non-finite"):
+                oc_mod.solve_trajectory(mock_ocp, initial_state=bad_state)
+        finally:
+            oc_mod._HAS_CROCODDYL = original
+
+    def test_accepts_valid_initial_state(self) -> None:
+        """solve_trajectory should proceed normally with a valid finite initial state."""
+        import pinocchio_models.addons.crocoddyl.optimal_control as oc_mod
+
+        original_flag = oc_mod._HAS_CROCODDYL
+        original_cro = getattr(oc_mod, "crocoddyl", None)
+        oc_mod._HAS_CROCODDYL = True
+        mock_cro = MagicMock()
+        mock_solver = MagicMock()
+        mock_solver.xs = [np.zeros(10)]
+        mock_solver.us = [np.zeros(3)]
+        mock_cro.SolverDDP.return_value = mock_solver
+        oc_mod.crocoddyl = mock_cro
+        try:
+            mock_ocp = MagicMock()
+            valid_state = np.zeros(10)
+            states, controls = oc_mod.solve_trajectory(
+                mock_ocp, initial_state=valid_state
+            )
+            assert len(states) == 1
+            assert len(controls) == 1
+        finally:
+            oc_mod._HAS_CROCODDYL = original_flag
+            if original_cro is None:
+                del oc_mod.crocoddyl
+            else:
+                oc_mod.crocoddyl = original_cro

--- a/tests/unit/addons/test_pink_ik.py
+++ b/tests/unit/addons/test_pink_ik.py
@@ -148,11 +148,11 @@ class TestSolvePoseDbCContracts:
     def test_warns_when_ik_does_not_converge(self) -> None:
         """solve_pose should warn when max_iterations exhausted without convergence."""
         import importlib
+        from unittest.mock import MagicMock, patch
 
         import numpy as np
 
         import pinocchio_models.addons.pink.ik_solver as ik_mod
-        from unittest.mock import MagicMock, patch
 
         importlib.reload(ik_mod)
         ik_mod._HAS_PINK = True
@@ -172,10 +172,10 @@ class TestSolvePoseDbCContracts:
         mock_problem.data = MagicMock()
         targets = {"frame1": np.eye(4)}
 
-        with patch.object(ik_mod, "_build_target_tasks", return_value=[MagicMock()]):
-            with patch.object(ik_mod, "_ik_step", return_value=mock_configuration):
-                with patch.object(ik_mod, "_check_convergence", return_value=False):
-                    with pytest.warns(UserWarning, match="IK did not converge"):
-                        ik_mod.solve_pose(
-                            mock_problem, targets, max_iterations=5
-                        )
+        with (
+            patch.object(ik_mod, "_build_target_tasks", return_value=[MagicMock()]),
+            patch.object(ik_mod, "_ik_step", return_value=mock_configuration),
+            patch.object(ik_mod, "_check_convergence", return_value=False),
+            pytest.warns(UserWarning, match="IK did not converge"),
+        ):
+            ik_mod.solve_pose(mock_problem, targets, max_iterations=5)

--- a/tests/unit/addons/test_pink_ik.py
+++ b/tests/unit/addons/test_pink_ik.py
@@ -100,3 +100,82 @@ class TestUrdfValidation:
 
             with pytest.raises(ValueError, match="must not be empty"):
                 ik_mod.create_ik_problem("", ["frame1"])
+
+
+class TestSolvePoseDbCContracts:
+    """DbC contracts for solve_pose (issue #124)."""
+
+    def test_rejects_non_matrix_target_pose(self) -> None:
+        """targets values must be (4,4) SE(3) matrices."""
+        import importlib
+
+        import numpy as np
+
+        import pinocchio_models.addons.pink.ik_solver as ik_mod
+
+        importlib.reload(ik_mod)
+        ik_mod._HAS_PINK = True
+
+        from unittest.mock import MagicMock
+
+        mock_problem = MagicMock()
+        bad_targets = {"frame1": np.zeros((3, 4))}  # wrong shape
+
+        with pytest.raises(ValueError, match="SE\\(3\\) pose.*must be a \\(4, 4\\)"):
+            ik_mod.solve_pose(mock_problem, bad_targets)
+
+    def test_rejects_non_finite_target_pose(self) -> None:
+        """targets values must be finite."""
+        import importlib
+
+        import numpy as np
+
+        import pinocchio_models.addons.pink.ik_solver as ik_mod
+
+        importlib.reload(ik_mod)
+        ik_mod._HAS_PINK = True
+
+        from unittest.mock import MagicMock
+
+        mock_problem = MagicMock()
+        nan_pose = np.eye(4)
+        nan_pose[0, 0] = float("nan")
+        bad_targets = {"frame1": nan_pose}
+
+        with pytest.raises(ValueError, match="SE\\(3\\) pose.*non-finite"):
+            ik_mod.solve_pose(mock_problem, bad_targets)
+
+    def test_warns_when_ik_does_not_converge(self) -> None:
+        """solve_pose should warn when max_iterations exhausted without convergence."""
+        import importlib
+
+        import numpy as np
+
+        import pinocchio_models.addons.pink.ik_solver as ik_mod
+        from unittest.mock import MagicMock, patch
+
+        importlib.reload(ik_mod)
+        ik_mod._HAS_PINK = True
+
+        mock_pin = MagicMock()
+        mock_pin.neutral.return_value = np.zeros(7)
+        mock_pink_lib = MagicMock()
+        mock_configuration = MagicMock()
+        mock_configuration.q = np.zeros(7)
+        mock_pink_lib.Configuration.return_value = mock_configuration
+
+        ik_mod.pin = mock_pin
+        ik_mod.pink = mock_pink_lib
+
+        mock_problem = MagicMock()
+        mock_problem.model = MagicMock()
+        mock_problem.data = MagicMock()
+        targets = {"frame1": np.eye(4)}
+
+        with patch.object(ik_mod, "_build_target_tasks", return_value=[MagicMock()]):
+            with patch.object(ik_mod, "_ik_step", return_value=mock_configuration):
+                with patch.object(ik_mod, "_check_convergence", return_value=False):
+                    with pytest.warns(UserWarning, match="IK did not converge"):
+                        ik_mod.solve_pose(
+                            mock_problem, targets, max_iterations=5
+                        )


### PR DESCRIPTION
## Summary
- **Pink IK (`solve_pose`)**: precondition validates each target is a finite (4,4) SE(3) matrix; postcondition issues `UserWarning` when IK exhausts `max_iterations` without converging
- **Crocoddyl OC (`solve_trajectory`)**: precondition validates `initial_state` is finite when provided
- Tests written first (TDD) for all new contracts

Closes #124

## Test plan
- [x] 457 unit/integration tests pass (6 new tests added)
- [x] ruff check: zero violations
- [x] ruff format: no diffs
- [x] mypy: no errors on addons/

🤖 Generated with [Claude Code](https://claude.com/claude-code)