### PR TITLE
refactor: decompose top 5 oversized functions into helpers

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -256,4 +256,5 @@ The repository is in active maintenance. Shared model generation is established,
 | Date | Version | Changes |
 | --- | --- | --- |
 | 2026-04-06 | 1.0.0 | Initial repository specification for Pinocchio_Models. |
+| 2026-04-11 | 1.0.1 | Decomposed five oversized functions (#128) into single-purpose private helpers; behaviour preserved. |
 

--- a/src/pinocchio_models/__main__.py
+++ b/src/pinocchio_models/__main__.py
@@ -87,6 +87,31 @@ def _create_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _validate_cli_args(
+    parser: argparse.ArgumentParser, args: argparse.Namespace
+) -> None:
+    """DbC: validate numeric CLI arguments and exit via *parser* on failure."""
+    if args.mass <= 0:
+        parser.error(f"--mass must be positive, got {args.mass}")
+    if args.height <= 0:
+        parser.error(f"--height must be positive, got {args.height}")
+    if args.plates < 0:
+        parser.error(f"--plates must be non-negative, got {args.plates}")
+
+
+def _emit_urdf(exercise_name: str, urdf_str: str, output_dir: Path | None) -> None:
+    """Write *urdf_str* either to ``<output_dir>/<exercise>.urdf`` or stdout."""
+    if output_dir is not None:
+        output_dir.mkdir(parents=True, exist_ok=True)
+        out_path = output_dir / f"{exercise_name}.urdf"
+        out_path.write_text(urdf_str, encoding="utf-8")
+        logger.info("Wrote %s", out_path)
+    else:
+        stdout = sys.stdout
+        stdout.write(urdf_str)
+        stdout.write("\n")
+
+
 def main(argv: list[str] | None = None) -> int:
     """CLI entry point for Pinocchio model generation.
 
@@ -98,14 +123,7 @@ def main(argv: list[str] | None = None) -> int:
     """
     parser = _create_parser()
     args = parser.parse_args(argv)
-
-    # DbC: validate numeric CLI arguments
-    if args.mass <= 0:
-        parser.error(f"--mass must be positive, got {args.mass}")
-    if args.height <= 0:
-        parser.error(f"--height must be positive, got {args.height}")
-    if args.plates < 0:
-        parser.error(f"--plates must be non-negative, got {args.plates}")
+    _validate_cli_args(parser, args)
 
     logging.basicConfig(
         level=logging.DEBUG if args.verbose else logging.WARNING,
@@ -119,22 +137,12 @@ def main(argv: list[str] | None = None) -> int:
     for exercise_name in exercises:
         builder_fn = _BUILDERS[exercise_name]
         logger.info("Generating %s model", exercise_name)
-
         urdf_str = builder_fn(
             body_mass=args.mass,
             height=args.height,
             plate_mass_per_side=args.plates,
         )
-
-        if args.output_dir is not None:
-            args.output_dir.mkdir(parents=True, exist_ok=True)
-            out_path = args.output_dir / f"{exercise_name}.urdf"
-            out_path.write_text(urdf_str, encoding="utf-8")
-            logger.info("Wrote %s", out_path)
-        else:
-            stdout = sys.stdout
-            stdout.write(urdf_str)
-            stdout.write("\n")
+        _emit_urdf(exercise_name, urdf_str, args.output_dir)
 
     return 0
 

--- a/src/pinocchio_models/optimization/trajectory_optimizer.py
+++ b/src/pinocchio_models/optimization/trajectory_optimizer.py
@@ -73,6 +73,51 @@ class TrajectoryResult:
     iterations: int
 
 
+def _build_phase_arrays(
+    objective: ExerciseObjective,
+) -> tuple[list[str], np.ndarray, np.ndarray]:
+    """Return ``(joint_names, phase_fracs, phase_angles)`` for *objective*.
+
+    ``joint_names`` is the sorted union of joints across all phases.
+    ``phase_fracs`` has shape ``(n_phases,)`` and ``phase_angles`` has shape
+    ``(n_phases, n_joints)``.
+    """
+    all_joints: set[str] = set()
+    for phase in objective.phases:
+        all_joints.update(phase.target_joints.keys())
+    joint_names = sorted(all_joints)
+    n_joints = len(joint_names)
+
+    phase_fracs = np.array([p.fraction for p in objective.phases])
+    phase_angles = np.zeros((len(objective.phases), n_joints))
+    for p_idx, phase in enumerate(objective.phases):
+        for k, jname in enumerate(joint_names):
+            phase_angles[p_idx, k] = phase.target_joints.get(jname, 0.0)
+    return joint_names, phase_fracs, phase_angles
+
+
+def _interpolate_keyframes(
+    phase_fracs: np.ndarray, phase_angles: np.ndarray, n_frames: int
+) -> np.ndarray:
+    """Linearly interpolate keyframes from phase boundaries using numpy ops."""
+    fractions = np.linspace(0.0, 1.0, n_frames)
+
+    # np.searchsorted finds the insertion point; clamp to valid phase indices
+    indices = np.searchsorted(phase_fracs, fractions, side="right") - 1
+    indices = np.clip(indices, 0, len(phase_fracs) - 2)
+    next_indices = indices + 1
+
+    # Vectorised alpha computation
+    denom = phase_fracs[next_indices] - phase_fracs[indices]
+    safe_denom = np.where(denom == 0.0, 1.0, denom)
+    alpha = np.where(denom == 0.0, 0.0, (fractions - phase_fracs[indices]) / safe_denom)
+
+    # Vectorised interpolation: v0 + alpha * (v1 - v0)
+    v0 = phase_angles[indices]  # (n_frames, n_joints)
+    v1 = phase_angles[next_indices]  # (n_frames, n_joints)
+    return v0 + alpha[:, np.newaxis] * (v1 - v0)
+
+
 def interpolate_phases(objective: ExerciseObjective, n_frames: int = 50) -> np.ndarray:
     """Linearly interpolate between exercise phases to generate keyframes.
 
@@ -92,35 +137,6 @@ def interpolate_phases(objective: ExerciseObjective, n_frames: int = 50) -> np.n
         raise ValueError(f"n_frames must be >= 2, got {n_frames}")
     if not objective.phases:
         raise ValueError("objective must have at least one phase")
-    all_joints: set[str] = set()
-    for phase in objective.phases:
-        all_joints.update(phase.target_joints.keys())
-    joint_names = sorted(all_joints)
-    n_joints = len(joint_names)
 
-    # Build phase boundary arrays for vectorised lookup
-    phase_fracs = np.array([p.fraction for p in objective.phases])
-    phase_angles = np.zeros((len(objective.phases), n_joints))
-    for p_idx, phase in enumerate(objective.phases):
-        for k, jname in enumerate(joint_names):
-            phase_angles[p_idx, k] = phase.target_joints.get(jname, 0.0)
-
-    fractions = np.linspace(0.0, 1.0, n_frames)
-    keyframes = np.zeros((n_frames, n_joints))
-
-    # np.searchsorted finds the insertion point; clamp to valid phase indices
-    indices = np.searchsorted(phase_fracs, fractions, side="right") - 1
-    indices = np.clip(indices, 0, len(objective.phases) - 2)
-    next_indices = indices + 1
-
-    # Vectorised alpha computation
-    denom = phase_fracs[next_indices] - phase_fracs[indices]
-    safe_denom = np.where(denom == 0.0, 1.0, denom)
-    alpha = np.where(denom == 0.0, 0.0, (fractions - phase_fracs[indices]) / safe_denom)
-
-    # Vectorised interpolation: v0 + alpha * (v1 - v0)
-    v0 = phase_angles[indices]  # (n_frames, n_joints)
-    v1 = phase_angles[next_indices]  # (n_frames, n_joints)
-    keyframes = v0 + alpha[:, np.newaxis] * (v1 - v0)
-
-    return keyframes
+    _joint_names, phase_fracs, phase_angles = _build_phase_arrays(objective)
+    return _interpolate_keyframes(phase_fracs, phase_angles, n_frames)

--- a/src/pinocchio_models/shared/contact/contact_model.py
+++ b/src/pinocchio_models/shared/contact/contact_model.py
@@ -94,6 +94,43 @@ def _foot_corner_contacts(frame_name: str) -> list[ContactPoint]:
     ]
 
 
+def _both_feet_contacts() -> list[ContactPoint]:
+    """Return foot corner contacts for both left and right feet."""
+    return _foot_corner_contacts("foot_l") + _foot_corner_contacts("foot_r")
+
+
+def _bench_contact_for(exercise_name: str) -> ContactPoint | None:
+    """Return the back-on-bench contact point if *exercise_name* needs one."""
+    if exercise_name != "bench_press":
+        return None
+    return ContactPoint(
+        frame_name="torso",
+        local_position=(0.0, 0.0, -0.05),
+        normal=(0.0, 0.0, 1.0),
+        mu=0.6,
+    )
+
+
+def _barbell_contacts_for(exercise_name: str) -> list[ContactPoint] | None:
+    """Return hand-on-barbell contacts for barbell-grip exercises."""
+    if exercise_name not in ("deadlift", "snatch", "clean_and_jerk"):
+        return None
+    return [
+        ContactPoint(
+            frame_name="hand_l",
+            local_position=(0.0, 0.0, 0.0),
+            normal=(0.0, 0.0, 1.0),
+            mu=0.9,
+        ),
+        ContactPoint(
+            frame_name="hand_r",
+            local_position=(0.0, 0.0, 0.0),
+            normal=(0.0, 0.0, 1.0),
+            mu=0.9,
+        ),
+    ]
+
+
 def get_exercise_contacts(exercise_name: str, model: Any = None) -> ContactSpec:
     """Return contact specification for the given exercise.
 
@@ -124,37 +161,8 @@ def get_exercise_contacts(exercise_name: str, model: Any = None) -> ContactSpec:
             f"Valid names: {sorted(VALID_EXERCISE_NAMES)}"
         )
 
-    foot_contacts = _foot_corner_contacts("foot_l") + _foot_corner_contacts("foot_r")
-
-    bench_contact: ContactPoint | None = None
-    barbell_contacts: list[ContactPoint] | None = None
-
-    if exercise_name == "bench_press":
-        bench_contact = ContactPoint(
-            frame_name="torso",
-            local_position=(0.0, 0.0, -0.05),
-            normal=(0.0, 0.0, 1.0),
-            mu=0.6,
-        )
-
-    if exercise_name in ("deadlift", "snatch", "clean_and_jerk"):
-        barbell_contacts = [
-            ContactPoint(
-                frame_name="hand_l",
-                local_position=(0.0, 0.0, 0.0),
-                normal=(0.0, 0.0, 1.0),
-                mu=0.9,
-            ),
-            ContactPoint(
-                frame_name="hand_r",
-                local_position=(0.0, 0.0, 0.0),
-                normal=(0.0, 0.0, 1.0),
-                mu=0.9,
-            ),
-        ]
-
     return ContactSpec(
-        foot_contacts=foot_contacts,
-        bench_contact=bench_contact,
-        barbell_contacts=barbell_contacts,
+        foot_contacts=_both_feet_contacts(),
+        bench_contact=_bench_contact_for(exercise_name),
+        barbell_contacts=_barbell_contacts_for(exercise_name),
     )

--- a/src/pinocchio_models/shared/contracts/postconditions.py
+++ b/src/pinocchio_models/shared/contracts/postconditions.py
@@ -15,31 +15,24 @@ import xml.etree.ElementTree as ET
 logger = logging.getLogger(__name__)
 
 
-def ensure_valid_urdf(xml_string: str) -> ET.Element:
-    """Parse *xml_string* and return the root element.
-
-    Validates:
-    1. Well-formed XML with a ``<robot>`` root tag.
-    2. Every joint's ``child`` link name exists in the declared link set.
-    3. No link appears as ``child`` of more than one joint (single-parent rule).
-
-    Parent link names are checked with a warning only, because the body model
-    uses resolved parent aliases (e.g. ``torso_l`` → ``torso``) that are
-    structurally intentional and do not need to match a declared link name.
-
-    Raises ValueError if any check fails.
-    """
+def _parse_robot_root(xml_string: str) -> ET.Element:
+    """Parse *xml_string* and verify the root element is ``<robot>``."""
     try:
         root = ET.fromstring(xml_string)  # nosec B314 — parsing self-generated XML
     except ET.ParseError as exc:
         raise ValueError(f"Generated URDF is not well-formed XML: {exc}") from exc
     if root.tag != "robot":
         raise ValueError(f"URDF root must be <robot>, got <{root.tag}>")
+    return root
 
-    link_names: set[str] = {
-        el.get("name", "") for el in root.findall("link") if el.get("name")
-    }
 
+def _collect_link_names(root: ET.Element) -> set[str]:
+    """Return the set of declared ``<link name=...>`` values under *root*."""
+    return {el.get("name", "") for el in root.findall("link") if el.get("name")}
+
+
+def _validate_joint_links(root: ET.Element, link_names: set[str]) -> None:
+    """Validate joint parent/child references and the single-parent rule."""
     child_parent_map: dict[str, str] = {}
     for joint in root.findall("joint"):
         joint_name = joint.get("name", "<unnamed>")
@@ -79,6 +72,24 @@ def ensure_valid_urdf(xml_string: str) -> ET.Element:
         if child_link:
             child_parent_map[child_link] = joint_name
 
+
+def ensure_valid_urdf(xml_string: str) -> ET.Element:
+    """Parse *xml_string* and return the root element.
+
+    Validates:
+    1. Well-formed XML with a ``<robot>`` root tag.
+    2. Every joint's ``child`` link name exists in the declared link set.
+    3. No link appears as ``child`` of more than one joint (single-parent rule).
+
+    Parent link names are checked with a warning only, because the body model
+    uses resolved parent aliases (e.g. ``torso_l`` → ``torso``) that are
+    structurally intentional and do not need to match a declared link name.
+
+    Raises ValueError if any check fails.
+    """
+    root = _parse_robot_root(xml_string)
+    link_names = _collect_link_names(root)
+    _validate_joint_links(root, link_names)
     return root
 
 

--- a/src/pinocchio_models/shared/utils/urdf_helpers.py
+++ b/src/pinocchio_models/shared/utils/urdf_helpers.py
@@ -263,6 +263,48 @@ def set_joint_default(
             joint.set("initial_position", f"{value:.6f}")
 
 
+def _import_pinocchio() -> Any:
+    """Import and return the ``pinocchio`` module, with a clear error message."""
+    try:
+        import pinocchio as pin
+    except ImportError as exc:
+        raise ImportError(
+            "pinocchio and numpy are required for get_initial_configuration. "
+            "Install with: pip install pinocchio-models[all-addons]"
+        ) from exc
+    return pin
+
+
+def _parse_initial_positions(xml_str: str) -> list[tuple[str, float]]:
+    """Extract ``(joint_name, initial_position)`` pairs from URDF metadata."""
+    root = ET.fromstring(xml_str)  # nosec B314 -- xml_str is internally generated URDF
+    pairs: list[tuple[str, float]] = []
+    for joint_el in root.findall("joint"):
+        initial_pos_str = joint_el.get("initial_position")
+        if initial_pos_str is None:
+            continue
+        joint_name = joint_el.get("name", "")
+        pairs.append((joint_name, float(initial_pos_str)))
+    return pairs
+
+
+def _apply_initial_positions(
+    model: Any, q: Any, initial_positions: list[tuple[str, float]]
+) -> None:
+    """Write each ``(name, value)`` pair onto the matching DOF index of *q*."""
+    for joint_name, value in initial_positions:
+        try:
+            joint_id = model.getJointId(joint_name)
+        except (RuntimeError, KeyError) as _e:
+            logger.warning("Joint %s not found in model: %s", joint_name, _e)
+            continue
+        if joint_id >= len(model.joints):
+            continue
+        joint = model.joints[joint_id]
+        if joint.nq == 1:
+            q[joint.idx_q] = value
+
+
 def get_initial_configuration(model: Any, xml_str: str) -> Any:
     """Build a Pinocchio configuration vector from ``initial_position`` metadata.
 
@@ -312,33 +354,8 @@ def get_initial_configuration(model: Any, xml_str: str) -> Any:
         q0 = get_initial_configuration(model, urdf_str)
         pin.forwardKinematics(model, data, q0)
     """
-    try:
-        import pinocchio as pin
-    except ImportError as exc:
-        raise ImportError(
-            "pinocchio and numpy are required for get_initial_configuration. "
-            "Install with: pip install pinocchio-models[all-addons]"
-        ) from exc
-
+    pin = _import_pinocchio()
     q = pin.neutral(model)
-
-    root = ET.fromstring(xml_str)  # nosec B314 -- xml_str is internally generated URDF
-    for joint_el in root.findall("joint"):
-        initial_pos_str = joint_el.get("initial_position")
-        if initial_pos_str is None:
-            continue
-        joint_name = joint_el.get("name", "")
-        try:
-            joint_id = model.getJointId(joint_name)
-        except (RuntimeError, KeyError) as _e:
-            logger.warning("Joint %s not found in model: %s", joint_name, _e)
-            continue
-        if joint_id >= len(model.joints):
-            continue
-        joint = model.joints[joint_id]
-        idx_q = joint.idx_q
-        nq_j = joint.nq
-        if nq_j == 1:
-            q[idx_q] = float(initial_pos_str)
-
+    initial_positions = _parse_initial_positions(xml_str)
+    _apply_initial_positions(model, q, initial_positions)
     return q

--- a/tests/unit/optimization/test_exercise_objectives.py
+++ b/tests/unit/optimization/test_exercise_objectives.py
@@ -11,6 +11,8 @@ from pinocchio_models.optimization.exercise_objectives import (
 from pinocchio_models.optimization.trajectory_optimizer import (
     TrajectoryConfig,
     TrajectoryResult,
+    _build_phase_arrays,
+    _interpolate_keyframes,
     interpolate_phases,
 )
 
@@ -221,3 +223,20 @@ class TestTrajectoryResult:
         assert result.converged is True
         assert result.cost == pytest.approx(0.42)
         assert result.joint_positions.shape == (n, nj)
+
+
+class TestInterpolatePhasesHelpers:
+    def test_build_phase_arrays_unions_joint_names(self) -> None:
+        objective = get_exercise_objective("back_squat")
+        joint_names, phase_fracs, phase_angles = _build_phase_arrays(objective)
+        assert joint_names == sorted(joint_names)
+        assert phase_fracs.shape == (len(objective.phases),)
+        assert phase_angles.shape == (len(objective.phases), len(joint_names))
+
+    def test_interpolate_keyframes_endpoints_match_phases(self) -> None:
+        phase_fracs = np.array([0.0, 0.5, 1.0])
+        phase_angles = np.array([[0.0, 1.0], [2.0, 3.0], [4.0, 5.0]])
+        keyframes = _interpolate_keyframes(phase_fracs, phase_angles, n_frames=5)
+        assert keyframes.shape == (5, 2)
+        np.testing.assert_allclose(keyframes[0], phase_angles[0])
+        np.testing.assert_allclose(keyframes[-1], phase_angles[-1])

--- a/tests/unit/shared/test_contact_model.py
+++ b/tests/unit/shared/test_contact_model.py
@@ -10,8 +10,31 @@ from pinocchio_models.shared.body.body_model import create_full_body
 from pinocchio_models.shared.contact.contact_model import (
     ContactPoint,
     ContactSpec,
+    _barbell_contacts_for,
+    _bench_contact_for,
+    _both_feet_contacts,
     get_exercise_contacts,
 )
+
+
+class TestExerciseContactHelpers:
+    def test_both_feet_returns_eight_corner_points(self) -> None:
+        feet = _both_feet_contacts()
+        assert len(feet) == 8
+        assert {c.frame_name for c in feet} == {"foot_l", "foot_r"}
+
+    def test_bench_contact_only_for_bench_press(self) -> None:
+        assert _bench_contact_for("back_squat") is None
+        bench = _bench_contact_for("bench_press")
+        assert bench is not None
+        assert bench.frame_name == "torso"
+
+    def test_barbell_contacts_for_barbell_lifts(self) -> None:
+        assert _barbell_contacts_for("back_squat") is None
+        for name in ("deadlift", "snatch", "clean_and_jerk"):
+            contacts = _barbell_contacts_for(name)
+            assert contacts is not None
+            assert {c.frame_name for c in contacts} == {"hand_l", "hand_r"}
 
 
 class TestContactPoint:

--- a/tests/unit/shared/test_postconditions.py
+++ b/tests/unit/shared/test_postconditions.py
@@ -1,8 +1,13 @@
 """Tests for postcondition contract guards."""
 
+import xml.etree.ElementTree as ET
+
 import pytest
 
 from pinocchio_models.shared.contracts.postconditions import (
+    _collect_link_names,
+    _parse_robot_root,
+    _validate_joint_links,
     ensure_positive_definite_inertia,
     ensure_positive_mass,
     ensure_valid_urdf,
@@ -21,6 +26,43 @@ class TestEnsureValidUrdf:
     def test_rejects_non_robot_root(self) -> None:
         with pytest.raises(ValueError, match="root must be <robot>"):
             ensure_valid_urdf("<model/>")
+
+
+class TestParseRobotRoot:
+    def test_returns_root_for_valid_xml(self) -> None:
+        root = _parse_robot_root('<robot name="r"/>')
+        assert root.tag == "robot"
+
+    def test_rejects_non_robot_tag(self) -> None:
+        with pytest.raises(ValueError, match="root must be <robot>"):
+            _parse_robot_root("<thing/>")
+
+
+class TestCollectLinkNames:
+    def test_collects_named_links(self) -> None:
+        root = ET.fromstring('<robot><link name="a"/><link name="b"/><link/></robot>')
+        assert _collect_link_names(root) == {"a", "b"}
+
+
+class TestValidateJointLinks:
+    def test_rejects_unknown_child_link(self) -> None:
+        root = ET.fromstring(
+            '<robot><link name="a"/>'
+            '<joint name="j"><parent link="a"/><child link="ghost"/></joint>'
+            "</robot>"
+        )
+        with pytest.raises(ValueError, match="unknown child link"):
+            _validate_joint_links(root, {"a"})
+
+    def test_rejects_duplicate_child_link(self) -> None:
+        root = ET.fromstring(
+            '<robot><link name="a"/><link name="b"/>'
+            '<joint name="j1"><parent link="a"/><child link="b"/></joint>'
+            '<joint name="j2"><parent link="a"/><child link="b"/></joint>'
+            "</robot>"
+        )
+        with pytest.raises(ValueError, match="exactly one parent joint"):
+            _validate_joint_links(root, {"a", "b"})
 
 
 class TestEnsurePositiveMass:

--- a/tests/unit/shared/test_urdf_helpers.py
+++ b/tests/unit/shared/test_urdf_helpers.py
@@ -5,6 +5,7 @@ import xml.etree.ElementTree as ET
 import pytest
 
 from pinocchio_models.shared.utils.urdf_helpers import (
+    _parse_initial_positions,
     add_fixed_joint,
     add_link,
     add_revolute_joint,
@@ -16,6 +17,29 @@ from pinocchio_models.shared.utils.urdf_helpers import (
     set_joint_default,
     vec3_str,
 )
+
+
+class TestParseInitialPositions:
+    def test_extracts_pairs_from_metadata(self) -> None:
+        xml_str = (
+            '<robot name="r">'
+            '<joint name="j1" initial_position="0.5"><parent link="a"/>'
+            '<child link="b"/></joint>'
+            '<joint name="j2"><parent link="b"/><child link="c"/></joint>'
+            '<joint name="j3" initial_position="-1.25"><parent link="c"/>'
+            '<child link="d"/></joint>'
+            "</robot>"
+        )
+        pairs = _parse_initial_positions(xml_str)
+        assert pairs == [("j1", 0.5), ("j3", -1.25)]
+
+    def test_returns_empty_when_no_metadata(self) -> None:
+        xml_str = (
+            '<robot name="r">'
+            '<joint name="j"><parent link="a"/><child link="b"/></joint>'
+            "</robot>"
+        )
+        assert _parse_initial_positions(xml_str) == []
 
 
 class TestVec3Str:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import tempfile
 from pathlib import Path
 
-from pinocchio_models.__main__ import main
+import pytest
+
+from pinocchio_models.__main__ import _emit_urdf, main
 
 
 class TestCLI:
@@ -48,3 +50,31 @@ class TestCLI:
         """When no --output-dir, output goes to stdout."""
         result = main(["deadlift"])
         assert result == 0
+
+
+class TestValidateCliArgs:
+    def test_rejects_non_positive_mass(self) -> None:
+        with pytest.raises(SystemExit):
+            main(["back_squat", "--mass", "0", "--output-dir", "."])
+
+    def test_accepts_valid_args(self) -> None:
+        # Smoke-test through main; non-positive mass would have raised SystemExit.
+        with tempfile.TemporaryDirectory() as tmpdir:
+            assert main(["back_squat", "--mass", "70", "--output-dir", tmpdir]) == 0
+
+
+class TestEmitUrdf:
+    def test_writes_urdf_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out_dir = Path(tmpdir) / "models"
+            _emit_urdf("back_squat", '<robot name="r"/>', out_dir)
+            urdf_path = out_dir / "back_squat.urdf"
+            assert urdf_path.exists()
+            assert "robot" in urdf_path.read_text()
+
+    def test_stdout_when_output_dir_is_none(
+        self, capsys: pytest.CaptureFixture
+    ) -> None:
+        _emit_urdf("squat", '<robot name="r"/>', None)
+        captured = capsys.readouterr()
+        assert "<robot" in captured.out


### PR DESCRIPTION
## Summary
- Fixes #128 by extracting single-purpose private helpers from the five largest Python functions flagged in the 2026-04-10 refresh assessment.
- Each public function is now a thin orchestrator: parse/validate then delegate to helpers. Behaviour, signatures, exceptions, and outputs are unchanged.
- Added 1-2 unit tests per extracted helper alongside existing tests, and updated the SPEC.md change log.

## Changes
- `urdf_helpers.get_initial_configuration` -> `_import_pinocchio`, `_parse_initial_positions`, `_apply_initial_positions`.
- `postconditions.ensure_valid_urdf` -> `_parse_robot_root`, `_collect_link_names`, `_validate_joint_links`.
- `contact_model.get_exercise_contacts` -> `_both_feet_contacts`, `_bench_contact_for`, `_barbell_contacts_for`.
- `__main__.main` -> `_validate_cli_args`, `_emit_urdf`.
- `trajectory_optimizer.interpolate_phases` -> `_build_phase_arrays`, `_interpolate_keyframes`.

## Test plan
- [x] `python3 -m ruff check .`
- [x] `python3 -m ruff format --check .`
- [x] `python3 -m pytest` for the affected unit test files (162 passed, 1 skipped due to missing optional `pinocchio`).

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>