### PR TITLE
refactor: split top 2 monolithic addon scripts (#129)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -257,4 +257,5 @@ The repository is in active maintenance. Shared model generation is established,
 | --- | --- | --- |
 | 2026-04-06 | 1.0.0 | Initial repository specification for Pinocchio_Models. |
 | 2026-04-11 | 1.0.1 | Decomposed five oversized functions (#128) into single-purpose private helpers; behaviour preserved. |
+| 2026-04-11 | 1.0.2 | Split top-2 monolithic addon scripts (#129): ``optimal_control.py`` and ``ik_solver.py`` now delegate to focused builder/task/config submodules. Public API and module attributes preserved. |
 

--- a/src/pinocchio_models/addons/crocoddyl/optimal_control.py
+++ b/src/pinocchio_models/addons/crocoddyl/optimal_control.py
@@ -12,42 +12,56 @@ Usage requires the optional ``crocoddyl`` extra::
 
 Note on Pinocchio energy API: There is no ``computeTotalEnergy``.
 Use ``computeKineticEnergy`` + ``computePotentialEnergy`` separately.
+
+This module is a thin facade. The heavy building blocks live in
+:mod:`optimal_control_builders` and the tunable constants in
+:mod:`optimal_control_config`. Public API and attribute names are
+preserved so existing imports and test mocks continue to work.
 """
 
 from __future__ import annotations
-
-from dataclasses import dataclass, field
-from typing import Any
 
 import numpy as np
 
 try:
     import crocoddyl
-    import pinocchio as pin
+    import pinocchio as pin  # noqa: F401  (re-exported for test mocks)
 
     _HAS_CROCODDYL = True
 except ImportError:
     _HAS_CROCODDYL = False
 
-from pinocchio_models.shared.contracts.preconditions import (
-    require_positive,
-    require_valid_exercise_name,
-    require_valid_urdf_string,
+from .optimal_control_builders import (
+    ExerciseOCP,
+    _assemble_shooting_problem,
+    _build_contact_models,
+    _build_ocp_common,
+    _OCPComponents,
+)
+from .optimal_control_config import (
+    CONTACT_BAUMGARTE_GAINS,
+    EFFORT_COST_WEIGHT,
+    FRICTION_CONE_FACETS,
+    FRICTION_COST_WEIGHT,
+    GROUND_FRICTION_MU,
+    STATE_REG_RUNNING_WEIGHT,
+    STATE_REG_TERMINAL_WEIGHT,
 )
 
-# --- Named constants for Crocoddyl OCP weights and physics ---
-# Cost weights used in the running and terminal cost models.
-EFFORT_COST_WEIGHT: float = 1e-3
-STATE_REG_RUNNING_WEIGHT: float = 1e-1
-STATE_REG_TERMINAL_WEIGHT: float = 1.0
-FRICTION_COST_WEIGHT: float = 1e-2
-
-# Baumgarte stabilisation gains for bilateral foot-ground contacts.
-CONTACT_BAUMGARTE_GAINS: tuple[float, float] = (0.0, 50.0)
-
-# Ground friction coefficient (Coulomb) and friction cone facets.
-GROUND_FRICTION_MU: float = 0.8
-FRICTION_CONE_FACETS: int = 4
+__all__ = [
+    "CONTACT_BAUMGARTE_GAINS",
+    "EFFORT_COST_WEIGHT",
+    "FRICTION_CONE_FACETS",
+    "FRICTION_COST_WEIGHT",
+    "GROUND_FRICTION_MU",
+    "STATE_REG_RUNNING_WEIGHT",
+    "STATE_REG_TERMINAL_WEIGHT",
+    "ExerciseOCP",
+    "create_cyclic_ocp",
+    "create_exercise_ocp",
+    "extract_joint_torques",
+    "solve_trajectory",
+]
 
 
 def _require_crocoddyl() -> None:
@@ -57,195 +71,6 @@ def _require_crocoddyl() -> None:
             "Crocoddyl is not installed. "
             "Install with: pip install pinocchio-models[crocoddyl]"
         )
-
-
-@dataclass
-class ExerciseOCP:
-    """Encapsulates a Crocoddyl optimal control problem for an exercise.
-
-    Stores the Pinocchio model, the Crocoddyl shooting problem,
-    and solver configuration.
-    """
-
-    model: Any
-    state: Any
-    actuation: Any
-    problem: Any
-    dt: float
-    n_steps: int
-    running_models: list[Any] = field(default_factory=list)
-    terminal_model: Any = None
-
-
-def _build_contact_models(
-    model: Any,
-    state: Any,
-    foot_frame_names: list[str],
-) -> Any:
-    """Build a ContactModelMultiple with 3D foot contacts.
-
-    Each foot frame gets a :class:`crocoddyl.ContactModel3D` enforcing
-    the frame position (bilateral, zero-velocity contact on the ground
-    plane).
-
-    Parameters
-    ----------
-    model : pinocchio.Model
-        Pinocchio model.
-    state : crocoddyl.StateMultibody
-        State object wrapping *model*.
-    foot_frame_names : list[str]
-        Frame names to constrain (e.g. ``["foot_l", "foot_r"]``).
-
-    Returns
-    -------
-    crocoddyl.ContactModelMultiple
-        Contact model ready for use in a DAM.
-    """
-    contacts = crocoddyl.ContactModelMultiple(state, model.nv)
-    for name in foot_frame_names:
-        frame_id = model.getFrameId(name)
-        contact = crocoddyl.ContactModel3D(
-            state,
-            frame_id,
-            np.zeros(3),  # reference position (ground)
-            model.nv,
-            np.array(CONTACT_BAUMGARTE_GAINS),
-        )
-        contacts.addContact(f"{name}_contact", contact)
-    return contacts
-
-
-@dataclass
-class _OCPComponents:
-    """Intermediate components produced by _build_ocp_common.
-
-    Bundles the Pinocchio model, Crocoddyl state/actuation, cost
-    models, optional contacts, and the initial state vector so that
-    both ``create_exercise_ocp`` and ``create_cyclic_ocp`` can
-    customise the terminal cost before assembling the shooting problem.
-    """
-
-    model: Any
-    state: Any
-    actuation: Any
-    running_cost_model: Any
-    terminal_cost_model: Any
-    contacts: Any  # None when use_contacts is False
-    x0: Any  # ndarray
-
-
-def _build_ocp_common(
-    urdf_str: str,
-    exercise_name: str,
-    dt: float,
-    n_steps: int,
-    use_contacts: bool,
-) -> _OCPComponents:
-    """Build the shared OCP components used by both exercise and cyclic OCPs.
-
-    Validates inputs, constructs the Pinocchio model, state, actuation,
-    running cost (effort + state regularisation), terminal cost (state
-    regularisation), and optional foot-ground contacts with friction
-    cone costs.
-
-    Returns an ``_OCPComponents`` bundle that callers extend before
-    assembling the final shooting problem.
-    """
-    _require_crocoddyl()
-    require_valid_urdf_string(urdf_str)
-    require_valid_exercise_name(exercise_name)
-    require_positive(dt, "dt")
-    require_positive(float(n_steps), "n_steps")
-
-    model = pin.buildModelFromXML(urdf_str, pin.JointModelFreeFlyer())
-    state = crocoddyl.StateMultibody(model)
-    actuation = crocoddyl.ActuationModelFloatingBase(state)
-
-    # Running cost: effort regularization + state regularization
-    running_cost_model = crocoddyl.CostModelSum(state)
-    u_residual = crocoddyl.ResidualModelControl(state)
-    u_cost = crocoddyl.CostModelResidual(state, u_residual)
-    running_cost_model.addCost("effort", u_cost, EFFORT_COST_WEIGHT)
-
-    x_residual = crocoddyl.ResidualModelState(state)
-    x_cost = crocoddyl.CostModelResidual(state, x_residual)
-    running_cost_model.addCost("state_reg", x_cost, STATE_REG_RUNNING_WEIGHT)
-
-    # Terminal cost: state regularization
-    terminal_cost_model = crocoddyl.CostModelSum(state)
-    terminal_cost_model.addCost("state_reg", x_cost, STATE_REG_TERMINAL_WEIGHT)
-
-    # Optionally add contact constraints
-    contacts = None
-    if use_contacts:
-        foot_frames = ["foot_l", "foot_r"]
-        contacts = _build_contact_models(model, state, foot_frames)
-
-        for fname in foot_frames:
-            frame_id = model.getFrameId(fname)
-            cone = crocoddyl.FrictionCone(
-                np.eye(3),
-                GROUND_FRICTION_MU,
-                FRICTION_CONE_FACETS,
-                False,
-            )
-            friction_residual = crocoddyl.ResidualModelContactFrictionCone(
-                state, frame_id, cone, model.nv
-            )
-            friction_cost = crocoddyl.CostModelResidual(state, friction_residual)
-            running_cost_model.addCost(
-                f"{fname}_friction", friction_cost, FRICTION_COST_WEIGHT
-            )
-
-    x0 = np.concatenate([pin.neutral(model), np.zeros(model.nv)])
-
-    return _OCPComponents(
-        model=model,
-        state=state,
-        actuation=actuation,
-        running_cost_model=running_cost_model,
-        terminal_cost_model=terminal_cost_model,
-        contacts=contacts,
-        x0=x0,
-    )
-
-
-def _assemble_shooting_problem(
-    c: _OCPComponents, dt: float, n_steps: int
-) -> ExerciseOCP:
-    """Build integrated action models and shooting problem from components."""
-    if c.contacts is not None:
-        running_dam = crocoddyl.DifferentialActionModelContactFwdDynamics(
-            c.state, c.actuation, c.contacts, c.running_cost_model
-        )
-        terminal_dam = crocoddyl.DifferentialActionModelContactFwdDynamics(
-            c.state, c.actuation, c.contacts, c.terminal_cost_model
-        )
-    else:
-        running_dam = crocoddyl.DifferentialActionModelFreeFwdDynamics(
-            c.state, c.actuation, c.running_cost_model
-        )
-        terminal_dam = crocoddyl.DifferentialActionModelFreeFwdDynamics(
-            c.state, c.actuation, c.terminal_cost_model
-        )
-
-    running_models = [
-        crocoddyl.IntegratedActionModelEuler(running_dam, dt) for _ in range(n_steps)
-    ]
-    terminal_model = crocoddyl.IntegratedActionModelEuler(terminal_dam, 0.0)
-    problem = crocoddyl.ShootingProblem(c.x0, running_models, terminal_model)
-
-    return ExerciseOCP(
-        model=c.model,
-        state=c.state,
-        actuation=c.actuation,
-        problem=problem,
-        dt=dt,
-        n_steps=n_steps,
-        running_models=running_models,
-        terminal_model=terminal_model,
-    )
 
 
 def create_exercise_ocp(
@@ -277,6 +102,7 @@ def create_exercise_ocp(
     ExerciseOCP
         Configured OCP ready for solving.
     """
+    _require_crocoddyl()
     c = _build_ocp_common(urdf_str, exercise_name, dt, n_steps, use_contacts)
     return _assemble_shooting_problem(c, dt, n_steps)
 
@@ -317,6 +143,9 @@ def create_cyclic_ocp(
     ExerciseOCP
         Configured cyclic OCP ready for solving.
     """
+    _require_crocoddyl()
+    from pinocchio_models.shared.contracts.preconditions import require_positive
+
     require_positive(periodicity_weight, "periodicity_weight")
     c = _build_ocp_common(urdf_str, exercise_name, dt, n_steps, use_contacts)
 
@@ -390,3 +219,8 @@ def extract_joint_torques(
 
     _states, controls = trajectory
     return np.array(controls)
+
+
+# Re-export private helpers kept as module attributes for backward compatibility
+# (tests rely on ``hasattr(oc_mod, "_build_contact_models")`` and similar).
+__all__ += ["_OCPComponents", "_build_contact_models"]

--- a/src/pinocchio_models/addons/crocoddyl/optimal_control_builders.py
+++ b/src/pinocchio_models/addons/crocoddyl/optimal_control_builders.py
@@ -1,0 +1,230 @@
+"""Internal builders for the Crocoddyl optimal-control problem.
+
+Contains the helpers that assemble contact models, cost models,
+intermediate component bundles, and shooting problems. These are
+implementation details of :mod:`optimal_control` and are re-exported
+from the facade only where tests require attribute access
+(e.g. ``_build_contact_models``).
+
+Callers from :mod:`optimal_control` are expected to gate entry with
+``_require_crocoddyl()`` so that the functions here are only reached
+when the optional Crocoddyl and Pinocchio packages are importable.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+
+try:
+    import crocoddyl
+    import pinocchio as pin
+except ImportError:  # pragma: no cover - exercised via import guard tests
+    crocoddyl = None  # type: ignore[assignment]
+    pin = None  # type: ignore[assignment]
+
+from pinocchio_models.shared.contracts.preconditions import (
+    require_positive,
+    require_valid_exercise_name,
+    require_valid_urdf_string,
+)
+
+from .optimal_control_config import (
+    CONTACT_BAUMGARTE_GAINS,
+    EFFORT_COST_WEIGHT,
+    FRICTION_CONE_FACETS,
+    FRICTION_COST_WEIGHT,
+    GROUND_FRICTION_MU,
+    STATE_REG_RUNNING_WEIGHT,
+    STATE_REG_TERMINAL_WEIGHT,
+)
+
+
+@dataclass
+class ExerciseOCP:
+    """Encapsulates a Crocoddyl optimal control problem for an exercise.
+
+    Stores the Pinocchio model, the Crocoddyl shooting problem,
+    and solver configuration.
+    """
+
+    model: Any
+    state: Any
+    actuation: Any
+    problem: Any
+    dt: float
+    n_steps: int
+    running_models: list[Any] = field(default_factory=list)
+    terminal_model: Any = None
+
+
+def _build_contact_models(
+    model: Any,
+    state: Any,
+    foot_frame_names: list[str],
+) -> Any:
+    """Build a ContactModelMultiple with 3D foot contacts.
+
+    Each foot frame gets a :class:`crocoddyl.ContactModel3D` enforcing
+    the frame position (bilateral, zero-velocity contact on the ground
+    plane).
+
+    Parameters
+    ----------
+    model : pinocchio.Model
+        Pinocchio model.
+    state : crocoddyl.StateMultibody
+        State object wrapping *model*.
+    foot_frame_names : list[str]
+        Frame names to constrain (e.g. ``["foot_l", "foot_r"]``).
+
+    Returns
+    -------
+    crocoddyl.ContactModelMultiple
+        Contact model ready for use in a DAM.
+    """
+    contacts = crocoddyl.ContactModelMultiple(state, model.nv)
+    for name in foot_frame_names:
+        frame_id = model.getFrameId(name)
+        contact = crocoddyl.ContactModel3D(
+            state,
+            frame_id,
+            np.zeros(3),  # reference position (ground)
+            model.nv,
+            np.array(CONTACT_BAUMGARTE_GAINS),
+        )
+        contacts.addContact(f"{name}_contact", contact)
+    return contacts
+
+
+@dataclass
+class _OCPComponents:
+    """Intermediate components produced by _build_ocp_common.
+
+    Bundles the Pinocchio model, Crocoddyl state/actuation, cost
+    models, optional contacts, and the initial state vector so that
+    both ``create_exercise_ocp`` and ``create_cyclic_ocp`` can
+    customise the terminal cost before assembling the shooting problem.
+    """
+
+    model: Any
+    state: Any
+    actuation: Any
+    running_cost_model: Any
+    terminal_cost_model: Any
+    contacts: Any  # None when use_contacts is False
+    x0: Any  # ndarray
+
+
+def _build_ocp_common(
+    urdf_str: str,
+    exercise_name: str,
+    dt: float,
+    n_steps: int,
+    use_contacts: bool,
+) -> _OCPComponents:
+    """Build the shared OCP components used by both exercise and cyclic OCPs.
+
+    Validates inputs, constructs the Pinocchio model, state, actuation,
+    running cost (effort + state regularisation), terminal cost (state
+    regularisation), and optional foot-ground contacts with friction
+    cone costs.
+
+    Returns an ``_OCPComponents`` bundle that callers extend before
+    assembling the final shooting problem.
+    """
+    require_valid_urdf_string(urdf_str)
+    require_valid_exercise_name(exercise_name)
+    require_positive(dt, "dt")
+    require_positive(float(n_steps), "n_steps")
+
+    model = pin.buildModelFromXML(urdf_str, pin.JointModelFreeFlyer())
+    state = crocoddyl.StateMultibody(model)
+    actuation = crocoddyl.ActuationModelFloatingBase(state)
+
+    # Running cost: effort regularization + state regularization
+    running_cost_model = crocoddyl.CostModelSum(state)
+    u_residual = crocoddyl.ResidualModelControl(state)
+    u_cost = crocoddyl.CostModelResidual(state, u_residual)
+    running_cost_model.addCost("effort", u_cost, EFFORT_COST_WEIGHT)
+
+    x_residual = crocoddyl.ResidualModelState(state)
+    x_cost = crocoddyl.CostModelResidual(state, x_residual)
+    running_cost_model.addCost("state_reg", x_cost, STATE_REG_RUNNING_WEIGHT)
+
+    # Terminal cost: state regularization
+    terminal_cost_model = crocoddyl.CostModelSum(state)
+    terminal_cost_model.addCost("state_reg", x_cost, STATE_REG_TERMINAL_WEIGHT)
+
+    # Optionally add contact constraints
+    contacts = None
+    if use_contacts:
+        foot_frames = ["foot_l", "foot_r"]
+        contacts = _build_contact_models(model, state, foot_frames)
+
+        for fname in foot_frames:
+            frame_id = model.getFrameId(fname)
+            cone = crocoddyl.FrictionCone(
+                np.eye(3),
+                GROUND_FRICTION_MU,
+                FRICTION_CONE_FACETS,
+                False,
+            )
+            friction_residual = crocoddyl.ResidualModelContactFrictionCone(
+                state, frame_id, cone, model.nv
+            )
+            friction_cost = crocoddyl.CostModelResidual(state, friction_residual)
+            running_cost_model.addCost(
+                f"{fname}_friction", friction_cost, FRICTION_COST_WEIGHT
+            )
+
+    x0 = np.concatenate([pin.neutral(model), np.zeros(model.nv)])
+
+    return _OCPComponents(
+        model=model,
+        state=state,
+        actuation=actuation,
+        running_cost_model=running_cost_model,
+        terminal_cost_model=terminal_cost_model,
+        contacts=contacts,
+        x0=x0,
+    )
+
+
+def _assemble_shooting_problem(
+    c: _OCPComponents, dt: float, n_steps: int
+) -> ExerciseOCP:
+    """Build integrated action models and shooting problem from components."""
+    if c.contacts is not None:
+        running_dam = crocoddyl.DifferentialActionModelContactFwdDynamics(
+            c.state, c.actuation, c.contacts, c.running_cost_model
+        )
+        terminal_dam = crocoddyl.DifferentialActionModelContactFwdDynamics(
+            c.state, c.actuation, c.contacts, c.terminal_cost_model
+        )
+    else:
+        running_dam = crocoddyl.DifferentialActionModelFreeFwdDynamics(
+            c.state, c.actuation, c.running_cost_model
+        )
+        terminal_dam = crocoddyl.DifferentialActionModelFreeFwdDynamics(
+            c.state, c.actuation, c.terminal_cost_model
+        )
+
+    running_models = [
+        crocoddyl.IntegratedActionModelEuler(running_dam, dt) for _ in range(n_steps)
+    ]
+    terminal_model = crocoddyl.IntegratedActionModelEuler(terminal_dam, 0.0)
+    problem = crocoddyl.ShootingProblem(c.x0, running_models, terminal_model)
+
+    return ExerciseOCP(
+        model=c.model,
+        state=c.state,
+        actuation=c.actuation,
+        problem=problem,
+        dt=dt,
+        n_steps=n_steps,
+        running_models=running_models,
+        terminal_model=terminal_model,
+    )

--- a/src/pinocchio_models/addons/crocoddyl/optimal_control_config.py
+++ b/src/pinocchio_models/addons/crocoddyl/optimal_control_config.py
@@ -1,0 +1,21 @@
+"""Named constants for the Crocoddyl optimal-control problem.
+
+Split out of :mod:`optimal_control` to keep the public module focused
+on orchestration. These weights and physics constants are re-exported
+from the facade for backward compatibility.
+"""
+
+from __future__ import annotations
+
+# --- Cost weights used in the running and terminal cost models. ---
+EFFORT_COST_WEIGHT: float = 1e-3
+STATE_REG_RUNNING_WEIGHT: float = 1e-1
+STATE_REG_TERMINAL_WEIGHT: float = 1.0
+FRICTION_COST_WEIGHT: float = 1e-2
+
+# Baumgarte stabilisation gains for bilateral foot-ground contacts.
+CONTACT_BAUMGARTE_GAINS: tuple[float, float] = (0.0, 50.0)
+
+# Ground friction coefficient (Coulomb) and friction cone facets.
+GROUND_FRICTION_MU: float = 0.8
+FRICTION_CONE_FACETS: int = 4

--- a/src/pinocchio_models/addons/pink/ik_solver.py
+++ b/src/pinocchio_models/addons/pink/ik_solver.py
@@ -6,6 +6,12 @@ place the barbell at target positions for each exercise phase.
 Usage requires the optional ``pink`` extra::
 
     pip install pinocchio-models[pink]
+
+This module is a thin facade. The Pink task builders and integration
+step helpers live in :mod:`ik_solver_tasks`; the exercise phase
+tables live in :mod:`ik_solver_phases`. Public API and attribute
+names are preserved so existing imports and test mocks continue to
+work.
 """
 
 from __future__ import annotations
@@ -32,7 +38,24 @@ from pinocchio_models.shared.contracts.preconditions import (
     require_valid_urdf_string,
 )
 
+# Re-export implementation helpers so tests can patch.object them on
+# this module (they are looked up by bare name in ``solve_pose``).
+from .ik_solver_phases import _EXERCISE_PHASES
+from .ik_solver_tasks import (
+    _build_ground_tasks,
+    _build_target_tasks,
+    _check_convergence,
+    _ik_step,
+)
+
 logger = logging.getLogger(__name__)
+
+__all__ = [
+    "IKProblem",
+    "compute_exercise_keyframes",
+    "create_ik_problem",
+    "solve_pose",
+]
 
 
 def _require_pink() -> None:
@@ -78,105 +101,6 @@ def create_ik_problem(urdf_str: str, target_frames: list[str]) -> IKProblem:
     data = model.createData()
 
     return IKProblem(model=model, data=data, target_frames=target_frames)
-
-
-def _build_target_tasks(targets: dict[str, np.ndarray]) -> list[Any]:
-    """Convert a targets dict into a list of Pink FrameTask objects.
-
-    Parameters
-    ----------
-    targets : dict[str, ndarray]
-        Mapping from frame name to desired SE(3) pose (4x4 matrix).
-
-    Returns
-    -------
-    list
-        Pink FrameTask instances with targets set.
-    """
-    tasks: list[Any] = []
-    for frame_name, target_pose in targets.items():
-        se3_target = pin.SE3(target_pose[:3, :3], target_pose[:3, 3])
-        task = pink.tasks.FrameTask(
-            frame_name,
-            position_cost=1.0,
-            orientation_cost=1.0,
-        )
-        task.set_target(se3_target)
-        tasks.append(task)
-    return tasks
-
-
-def _build_ground_tasks() -> list[Any]:
-    """Build foot-contact tasks that pin feet at Z=0.
-
-    Returns
-    -------
-    list
-        Two Pink FrameTask instances (foot_l, foot_r) with high position
-        weight to enforce ground contact.
-    """
-    tasks: list[Any] = []
-    for foot_name in ("foot_l", "foot_r"):
-        foot_task = pink.tasks.FrameTask(
-            foot_name,
-            position_cost=10.0,  # High weight to enforce contact
-            orientation_cost=0.1,
-        )
-        foot_task.set_target(pin.SE3.Identity())
-        tasks.append(foot_task)
-    return tasks
-
-
-def _ik_step(
-    configuration: Any,
-    model: Any,
-    data: Any,
-    tasks: list[Any],
-) -> Any:
-    """Advance the IK solver by one integration step.
-
-    Parameters
-    ----------
-    configuration : pink.Configuration
-        Current robot configuration.
-    model : pinocchio.Model
-        Pinocchio model.
-    data : pinocchio.Data
-        Pinocchio data.
-    tasks : list
-        Active Pink tasks for this step.
-
-    Returns
-    -------
-    pink.Configuration
-        Updated configuration after the integration step.
-    """
-    velocity = configuration.solve_ik(tasks, dt=0.01)
-    q = pin.integrate(model, configuration.q, velocity * 0.01)
-    return pink.Configuration(model, data, q)
-
-
-def _check_convergence(configuration: Any, tasks: list[Any], tolerance: float) -> bool:
-    """Return True if the maximum task error is below *tolerance*.
-
-    Parameters
-    ----------
-    configuration : pink.Configuration
-        Current robot configuration.
-    tasks : list
-        Active Pink tasks to evaluate.
-    tolerance : float
-        Convergence threshold.
-
-    Returns
-    -------
-    bool
-        True when all tasks are within tolerance.
-    """
-    error = float(
-        max(float(np.linalg.norm(task.compute_error(configuration))) for task in tasks)
-    )
-    return error < tolerance
 
 
 def solve_pose(
@@ -252,62 +176,6 @@ def solve_pose(
         )
 
     return configuration.q
-
-
-# Exercise phase definitions for keyframe generation.
-# Maps exercise_name -> list of (phase_name, hip_angle_fraction) pairs
-# where fraction 0.0 = start position, 1.0 = end position.
-_EXERCISE_PHASES: dict[str, list[tuple[str, float]]] = {
-    "back_squat": [
-        ("standing", 0.0),
-        ("descent_start", 0.2),
-        ("quarter_squat", 0.4),
-        ("half_squat", 0.6),
-        ("parallel", 0.8),
-        ("bottom", 1.0),
-        ("ascent_start", 0.8),
-        ("half_up", 0.5),
-        ("quarter_up", 0.25),
-        ("lockout", 0.0),
-    ],
-    "bench_press": [
-        ("lockout", 0.0),
-        ("descent_start", 0.15),
-        ("mid_descent", 0.4),
-        ("chest_touch", 1.0),
-        ("press_start", 0.9),
-        ("mid_press", 0.5),
-        ("near_lockout", 0.15),
-        ("lockout_end", 0.0),
-    ],
-    "deadlift": [
-        ("floor", 1.0),
-        ("break_floor", 0.85),
-        ("below_knee", 0.6),
-        ("above_knee", 0.4),
-        ("hip_drive", 0.2),
-        ("lockout", 0.0),
-    ],
-    "snatch": [
-        ("floor", 1.0),
-        ("first_pull", 0.7),
-        ("power_position", 0.3),
-        ("triple_ext", 0.0),
-        ("turnover", 0.5),
-        ("overhead_squat", 0.9),
-        ("recovery", 0.0),
-    ],
-    "clean_and_jerk": [
-        ("floor", 1.0),
-        ("first_pull", 0.7),
-        ("power_position", 0.3),
-        ("rack", 0.1),
-        ("dip", 0.3),
-        ("drive", 0.0),
-        ("split", 0.2),
-        ("recovery", 0.0),
-    ],
-}
 
 
 def compute_exercise_keyframes(

--- a/src/pinocchio_models/addons/pink/ik_solver_phases.py
+++ b/src/pinocchio_models/addons/pink/ik_solver_phases.py
@@ -1,0 +1,63 @@
+"""Keyframe phase tables used by the Pink IK exercise keyframe generator.
+
+Separated from :mod:`ik_solver` so the data tables can evolve without
+bloating the IK orchestration module. Re-exported from the facade for
+backward compatibility.
+"""
+
+from __future__ import annotations
+
+# Exercise phase definitions for keyframe generation.
+# Maps exercise_name -> list of (phase_name, hip_angle_fraction) pairs
+# where fraction 0.0 = start position, 1.0 = end position.
+_EXERCISE_PHASES: dict[str, list[tuple[str, float]]] = {
+    "back_squat": [
+        ("standing", 0.0),
+        ("descent_start", 0.2),
+        ("quarter_squat", 0.4),
+        ("half_squat", 0.6),
+        ("parallel", 0.8),
+        ("bottom", 1.0),
+        ("ascent_start", 0.8),
+        ("half_up", 0.5),
+        ("quarter_up", 0.25),
+        ("lockout", 0.0),
+    ],
+    "bench_press": [
+        ("lockout", 0.0),
+        ("descent_start", 0.15),
+        ("mid_descent", 0.4),
+        ("chest_touch", 1.0),
+        ("press_start", 0.9),
+        ("mid_press", 0.5),
+        ("near_lockout", 0.15),
+        ("lockout_end", 0.0),
+    ],
+    "deadlift": [
+        ("floor", 1.0),
+        ("break_floor", 0.85),
+        ("below_knee", 0.6),
+        ("above_knee", 0.4),
+        ("hip_drive", 0.2),
+        ("lockout", 0.0),
+    ],
+    "snatch": [
+        ("floor", 1.0),
+        ("first_pull", 0.7),
+        ("power_position", 0.3),
+        ("triple_ext", 0.0),
+        ("turnover", 0.5),
+        ("overhead_squat", 0.9),
+        ("recovery", 0.0),
+    ],
+    "clean_and_jerk": [
+        ("floor", 1.0),
+        ("first_pull", 0.7),
+        ("power_position", 0.3),
+        ("rack", 0.1),
+        ("dip", 0.3),
+        ("drive", 0.0),
+        ("split", 0.2),
+        ("recovery", 0.0),
+    ],
+}

--- a/src/pinocchio_models/addons/pink/ik_solver_tasks.py
+++ b/src/pinocchio_models/addons/pink/ik_solver_tasks.py
@@ -1,0 +1,127 @@
+"""Task/step helpers for the Pink IK solver.
+
+Low-level building blocks used by :func:`ik_solver.solve_pose`:
+
+- :func:`_build_target_tasks` converts a user-supplied targets dict
+  into Pink ``FrameTask`` instances.
+- :func:`_build_ground_tasks` emits foot-contact tasks pinning the
+  feet at Z=0.
+- :func:`_ik_step` advances the configuration by one integration step.
+- :func:`_check_convergence` evaluates the maximum task error.
+
+These helpers are re-exported from the facade :mod:`ik_solver` module
+so that tests can ``patch.object`` them on the facade while
+:func:`ik_solver.solve_pose` still calls them by bare name.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+try:
+    import pink
+    import pinocchio as pin
+except ImportError:  # pragma: no cover - exercised via import guard tests
+    pink = None  # type: ignore[assignment]
+    pin = None  # type: ignore[assignment]
+
+
+def _build_target_tasks(targets: dict[str, np.ndarray]) -> list[Any]:
+    """Convert a targets dict into a list of Pink FrameTask objects.
+
+    Parameters
+    ----------
+    targets : dict[str, ndarray]
+        Mapping from frame name to desired SE(3) pose (4x4 matrix).
+
+    Returns
+    -------
+    list
+        Pink FrameTask instances with targets set.
+    """
+    tasks: list[Any] = []
+    for frame_name, target_pose in targets.items():
+        se3_target = pin.SE3(target_pose[:3, :3], target_pose[:3, 3])
+        task = pink.tasks.FrameTask(
+            frame_name,
+            position_cost=1.0,
+            orientation_cost=1.0,
+        )
+        task.set_target(se3_target)
+        tasks.append(task)
+    return tasks
+
+
+def _build_ground_tasks() -> list[Any]:
+    """Build foot-contact tasks that pin feet at Z=0.
+
+    Returns
+    -------
+    list
+        Two Pink FrameTask instances (foot_l, foot_r) with high position
+        weight to enforce ground contact.
+    """
+    tasks: list[Any] = []
+    for foot_name in ("foot_l", "foot_r"):
+        foot_task = pink.tasks.FrameTask(
+            foot_name,
+            position_cost=10.0,  # High weight to enforce contact
+            orientation_cost=0.1,
+        )
+        foot_task.set_target(pin.SE3.Identity())
+        tasks.append(foot_task)
+    return tasks
+
+
+def _ik_step(
+    configuration: Any,
+    model: Any,
+    data: Any,
+    tasks: list[Any],
+) -> Any:
+    """Advance the IK solver by one integration step.
+
+    Parameters
+    ----------
+    configuration : pink.Configuration
+        Current robot configuration.
+    model : pinocchio.Model
+        Pinocchio model.
+    data : pinocchio.Data
+        Pinocchio data.
+    tasks : list
+        Active Pink tasks for this step.
+
+    Returns
+    -------
+    pink.Configuration
+        Updated configuration after the integration step.
+    """
+    velocity = configuration.solve_ik(tasks, dt=0.01)
+    q = pin.integrate(model, configuration.q, velocity * 0.01)
+    return pink.Configuration(model, data, q)
+
+
+def _check_convergence(configuration: Any, tasks: list[Any], tolerance: float) -> bool:
+    """Return True if the maximum task error is below *tolerance*.
+
+    Parameters
+    ----------
+    configuration : pink.Configuration
+        Current robot configuration.
+    tasks : list
+        Active Pink tasks to evaluate.
+    tolerance : float
+        Convergence threshold.
+
+    Returns
+    -------
+    bool
+        True when all tasks are within tolerance.
+    """
+    error = float(
+        max(float(np.linalg.norm(task.compute_error(configuration))) for task in tasks)
+    )
+    return error < tolerance


### PR DESCRIPTION
## Summary
- Splits `optimal_control.py` (392 LOC) into a thin facade (226) plus `optimal_control_builders.py` (230) and `optimal_control_config.py` (21).
- Splits `ik_solver.py` (388 LOC) into a thin facade (256) plus `ik_solver_tasks.py` (127) and `ik_solver_phases.py` (63).
- Both facades re-export helpers, dataclasses, and the Crocoddyl/Pinocchio/Pink module handles so existing `patch.object` / `sys.modules` reload mocks keep working. Public API unchanged.

Fixes #129

## Test plan
- [x] `python3 -m ruff check .`
- [x] `python3 -m ruff format --check .`
- [x] `python3 -m pytest tests/` (478 passed, 10 skipped for missing pinocchio/rust)
- [x] Targeted: `tests/unit/addons/test_crocoddyl_oc.py`, `tests/unit/addons/test_pink_ik.py`, `tests/unit/shared/test_contact_model.py` (52 passed)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>