### PR TITLE
refactor(#133): A-N Refresh P1 items batch 1

### DIFF
--- a/src/pinocchio_models/__main__.py
+++ b/src/pinocchio_models/__main__.py
@@ -43,17 +43,17 @@ _BUILDERS: dict[str, Callable[..., str]] = {
 }
 
 
-def _create_parser() -> argparse.ArgumentParser:
-    """Build the argument parser."""
-    parser = argparse.ArgumentParser(
-        prog="pinocchio-models",
-        description="Generate Pinocchio URDF models for barbell exercises.",
-    )
+def _add_exercise_argument(parser: argparse.ArgumentParser) -> None:
+    """Add the positional ``exercise`` argument (choices + ``all``)."""
     parser.add_argument(
         "exercise",
         choices=[*sorted(VALID_EXERCISE_NAMES), "all"],
         help="Exercise to generate (or 'all' for all exercises).",
     )
+
+
+def _add_anthropometry_arguments(parser: argparse.ArgumentParser) -> None:
+    """Add anthropometry / loading arguments (``--mass``, ``--height``, ``--plates``)."""
     parser.add_argument(
         "--mass",
         type=float,
@@ -72,6 +72,10 @@ def _create_parser() -> argparse.ArgumentParser:
         default=0.0,
         help="Plate mass per side in kg (default: 0.0).",
     )
+
+
+def _add_output_arguments(parser: argparse.ArgumentParser) -> None:
+    """Add output / verbosity arguments (``--output-dir``, ``-v``)."""
     parser.add_argument(
         "--output-dir",
         type=Path,
@@ -84,6 +88,17 @@ def _create_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Enable verbose logging.",
     )
+
+
+def _create_parser() -> argparse.ArgumentParser:
+    """Build the argument parser composed from focused helper groups."""
+    parser = argparse.ArgumentParser(
+        prog="pinocchio-models",
+        description="Generate Pinocchio URDF models for barbell exercises.",
+    )
+    _add_exercise_argument(parser)
+    _add_anthropometry_arguments(parser)
+    _add_output_arguments(parser)
     return parser
 
 

--- a/src/pinocchio_models/exercises/base.py
+++ b/src/pinocchio_models/exercises/base.py
@@ -85,25 +85,14 @@ class ExerciseModelBuilder(ABC):
         """
         return 0.3
 
-    def attach_barbell(
-        self,
-        robot: ET.Element,
-        body_links: dict[str, ET.Element],
-        barbell_links: dict[str, ET.Element],
-    ) -> None:
-        """Weld barbell shaft to both hands at grip position.
+    @staticmethod
+    def _attach_shaft_to_left_hand(robot: ET.Element, grip_offset: float) -> None:
+        """Weld ``barbell_shaft`` as a child of ``hand_l`` at ``-grip_offset``.
 
-        DRY: This default implementation covers bench press, deadlift,
-        snatch, and clean-and-jerk. The squat overrides this entirely
-        because the barbell sits on the torso, not in the hands.
+        URDF requires each link to have exactly one parent joint; attaching
+        barbell_shaft to hand_l only (and mirroring the right-hand grip via
+        a virtual link) keeps the topology a valid tree.
         """
-        grip_offset = self.config.barbell_spec.shaft_length * self.grip_offset_fraction
-
-        # Attach barbell_shaft to left hand — barbell_shaft has exactly one parent.
-        # URDF requires each link to have exactly one parent joint; the original
-        # code made barbell_shaft the child of two separate joints (one per hand),
-        # which is topologically invalid. The fix: barbell_shaft is the child of
-        # hand_l only.
         add_fixed_joint(
             robot,
             name="barbell_to_hand_l",
@@ -112,12 +101,15 @@ class ExerciseModelBuilder(ABC):
             origin_xyz=(0, -grip_offset, 0),
         )
 
-        # Add a zero-mass virtual grip anchor for the right hand.  hand_r already
-        # has wrist_r as its parent joint; URDF does not allow a second parent.
-        # The grip_r link hangs off barbell_shaft at the symmetric grip position,
-        # representing the right-hand contact point without creating a kinematic
-        # cycle.  This produces the valid chain:
-        #   hand_l → barbell_shaft → barbell_grip_r  (topology: valid tree)
+    @staticmethod
+    def _attach_virtual_grip_right(robot: ET.Element, grip_offset: float) -> None:
+        """Create the zero-mass ``barbell_grip_r`` anchor and fix it to the shaft.
+
+        hand_r already has ``wrist_r`` as its URDF parent, so adding a second
+        parent would be invalid.  We hang ``barbell_grip_r`` off
+        ``barbell_shaft`` at the symmetric grip position, producing the valid
+        tree ``hand_l -> barbell_shaft -> barbell_grip_r``.
+        """
         add_link(
             robot,
             name="barbell_grip_r",
@@ -134,6 +126,22 @@ class ExerciseModelBuilder(ABC):
             child="barbell_grip_r",
             origin_xyz=(0, 2 * grip_offset, 0),
         )
+
+    def attach_barbell(
+        self,
+        robot: ET.Element,
+        body_links: dict[str, ET.Element],
+        barbell_links: dict[str, ET.Element],
+    ) -> None:
+        """Weld barbell shaft to both hands at grip position.
+
+        DRY: This default implementation covers bench press, deadlift,
+        snatch, and clean-and-jerk. The squat overrides this entirely
+        because the barbell sits on the torso, not in the hands.
+        """
+        grip_offset = self.config.barbell_spec.shaft_length * self.grip_offset_fraction
+        self._attach_shaft_to_left_hand(robot, grip_offset)
+        self._attach_virtual_grip_right(robot, grip_offset)
 
     @abstractmethod
     def set_initial_pose(self, robot: ET.Element) -> None:

--- a/src/pinocchio_models/shared/body/body_anthropometrics.py
+++ b/src/pinocchio_models/shared/body/body_anthropometrics.py
@@ -80,6 +80,60 @@ def _seg(spec: BodyModelSpec, name: str) -> tuple[float, float, float]:
     return mass, length, radius
 
 
+def _resolve_bilateral_parent(parent_name: str, side: str) -> str:
+    """Return the actual parent-link name for *side*.
+
+    Bilateral segments (e.g. ``thigh``) must be suffixed with ``_l`` or
+    ``_r`` to match the link created on that side; central segments
+    (``pelvis``, ``torso``) already carry their own name and are returned
+    unchanged.
+    """
+    if parent_name in _BILATERAL_SEGMENTS:
+        return f"{parent_name}_{side}"
+    return parent_name
+
+
+def _add_limb_side_simple(
+    robot: ET.Element,
+    *,
+    side: str,
+    sign: float,
+    seg_name: str,
+    parent_name: str,
+    mass: float,
+    length: float,
+    radius: float,
+    inertia: tuple[float, float, float],
+    parent_offset_z: float,
+    parent_lateral_y: float,
+    coord_prefix: str,
+    range_min: float,
+    range_max: float,
+) -> None:
+    """Add a single-DOF limb segment (link + revolute joint) for one side."""
+    body_name = f"{seg_name}_{side}"
+    add_link(
+        robot,
+        name=body_name,
+        mass=mass,
+        origin_xyz=(0, 0, -length / 2.0),
+        ixx=inertia[0],
+        iyy=inertia[1],
+        izz=inertia[2],
+        visual_geometry=make_cylinder_geometry(radius, length),
+    )
+    add_revolute_joint(
+        robot,
+        name=f"{coord_prefix}_{side}",
+        parent=_resolve_bilateral_parent(parent_name, side),
+        child=body_name,
+        origin_xyz=(0, sign * parent_lateral_y, parent_offset_z),
+        axis=(0, 1, 0),
+        lower=range_min,
+        upper=range_max,
+    )
+
+
 def _add_bilateral_limb_simple(
     robot: ET.Element,
     spec: BodyModelSpec,
@@ -101,33 +155,22 @@ def _add_bilateral_limb_simple(
     mass, length, radius = _seg(spec, seg_name)
     inertia = cylinder_inertia(mass, radius, length)
 
-    for side, sign in [("l", -1.0), ("r", 1.0)]:
-        body_name = f"{seg_name}_{side}"
-        add_link(
+    for side, sign in (("l", -1.0), ("r", 1.0)):
+        _add_limb_side_simple(
             robot,
-            name=body_name,
+            side=side,
+            sign=sign,
+            seg_name=seg_name,
+            parent_name=parent_name,
             mass=mass,
-            origin_xyz=(0, 0, -length / 2.0),
-            ixx=inertia[0],
-            iyy=inertia[1],
-            izz=inertia[2],
-            visual_geometry=make_cylinder_geometry(radius, length),
-        )
-
-        parent_full = (
-            f"{parent_name}_{side}"
-            if parent_name in _BILATERAL_SEGMENTS
-            else parent_name
-        )
-        add_revolute_joint(
-            robot,
-            name=f"{coord_prefix}_{side}",
-            parent=parent_full,
-            child=body_name,
-            origin_xyz=(0, sign * parent_lateral_y, parent_offset_z),
-            axis=(0, 1, 0),
-            lower=range_min,
-            upper=range_max,
+            length=length,
+            radius=radius,
+            inertia=inertia,
+            parent_offset_z=parent_offset_z,
+            parent_lateral_y=parent_lateral_y,
+            coord_prefix=coord_prefix,
+            range_min=range_min,
+            range_max=range_max,
         )
 
 

--- a/tests/unit/exercises/test_attach_barbell_helpers.py
+++ b/tests/unit/exercises/test_attach_barbell_helpers.py
@@ -1,0 +1,93 @@
+"""Unit tests for the ``attach_barbell`` decomposition on ``ExerciseModelBuilder``.
+
+Introduced by the A-N Refresh 2026-04-14 batch (issue #133).  Covers the
+two extracted static helpers plus the public orchestrator.
+"""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+
+from pinocchio_models.exercises.base import ExerciseConfig, ExerciseModelBuilder
+
+
+class _MinimalBuilder(ExerciseModelBuilder):
+    @property
+    def exercise_name(self) -> str:
+        return "minimal"
+
+    def set_initial_pose(self, robot: ET.Element) -> None:
+        return None
+
+
+def test_attach_shaft_to_left_hand_creates_single_fixed_joint() -> None:
+    """Left-hand weld is a fixed joint from hand_l to barbell_shaft."""
+    robot = ET.Element("robot")
+    ExerciseModelBuilder._attach_shaft_to_left_hand(robot, grip_offset=0.3)
+    joints = robot.findall("joint")
+    assert len(joints) == 1
+    j = joints[0]
+    assert j.get("name") == "barbell_to_hand_l"
+    assert j.get("type") == "fixed"
+    assert j.find("parent").get("link") == "hand_l"  # type: ignore[union-attr]
+    assert j.find("child").get("link") == "barbell_shaft"  # type: ignore[union-attr]
+    origin = j.find("origin")
+    assert origin is not None
+    xyz = origin.get("xyz", "").split()
+    # y offset equals -grip_offset (left side is at -y)
+    assert float(xyz[1]) < 0
+
+
+def test_attach_virtual_grip_right_creates_link_and_joint() -> None:
+    """Right-hand anchor is a zero-mass link fixed to the shaft at +2*grip_offset."""
+    robot = ET.Element("robot")
+    ExerciseModelBuilder._attach_virtual_grip_right(robot, grip_offset=0.3)
+    # One new link and one new joint
+    assert len(robot.findall("link")) == 1
+    link = robot.find("link")
+    assert link is not None
+    assert link.get("name") == "barbell_grip_r"
+    joints = robot.findall("joint")
+    assert len(joints) == 1
+    j = joints[0]
+    assert j.get("name") == "barbell_to_hand_r"
+    assert j.find("parent").get("link") == "barbell_shaft"  # type: ignore[union-attr]
+    assert j.find("child").get("link") == "barbell_grip_r"  # type: ignore[union-attr]
+
+
+def test_attach_barbell_orchestrates_both_helpers() -> None:
+    """Public ``attach_barbell`` emits both weld-joints and the virtual link."""
+    builder = _MinimalBuilder(ExerciseConfig())
+    robot = ET.Element("robot")
+    builder.attach_barbell(robot, body_links={}, barbell_links={})
+
+    joint_names = {j.get("name") for j in robot.findall("joint")}
+    assert {"barbell_to_hand_l", "barbell_to_hand_r"}.issubset(joint_names)
+    link_names = {link.get("name") for link in robot.findall("link")}
+    assert "barbell_grip_r" in link_names
+
+
+def test_grip_offset_scales_linearly_with_fraction() -> None:
+    """Snatch uses a wider grip; the y-offset scales with ``grip_offset_fraction``."""
+
+    class WideGripBuilder(_MinimalBuilder):
+        @property
+        def grip_offset_fraction(self) -> float:
+            return 0.45
+
+    narrow = _MinimalBuilder(ExerciseConfig())
+    wide = WideGripBuilder(ExerciseConfig())
+
+    robot_n = ET.Element("robot")
+    narrow.attach_barbell(robot_n, body_links={}, barbell_links={})
+    robot_w = ET.Element("robot")
+    wide.attach_barbell(robot_w, body_links={}, barbell_links={})
+
+    def _left_y(robot: ET.Element) -> float:
+        j = robot.find("joint[@name='barbell_to_hand_l']")
+        assert j is not None
+        origin = j.find("origin")
+        assert origin is not None
+        return float(origin.get("xyz", "").split()[1])
+
+    assert abs(_left_y(robot_w)) > abs(_left_y(robot_n))

--- a/tests/unit/shared/test_bilateral_limb_helpers.py
+++ b/tests/unit/shared/test_bilateral_limb_helpers.py
@@ -1,0 +1,112 @@
+"""Unit tests for the bilateral-limb helpers in body_anthropometrics.py.
+
+Covers the decomposition of ``_add_bilateral_limb_simple`` introduced by
+A-N Refresh 2026-04-14 (issue #133).
+"""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+
+import pytest
+
+from pinocchio_models.shared.body.body_anthropometrics import (
+    BodyModelSpec,
+    _add_bilateral_limb_simple,
+    _add_limb_side_simple,
+    _resolve_bilateral_parent,
+    _seg,
+)
+from pinocchio_models.shared.utils.geometry import cylinder_inertia
+
+
+def test_resolve_bilateral_parent_uses_side_suffix_for_limbs() -> None:
+    """Bilateral segments get a side-specific parent name."""
+    assert _resolve_bilateral_parent("thigh", "l") == "thigh_l"
+    assert _resolve_bilateral_parent("thigh", "r") == "thigh_r"
+
+
+def test_resolve_bilateral_parent_leaves_central_segments_unchanged() -> None:
+    """Pelvis / torso / head are central and must not gain a suffix."""
+    assert _resolve_bilateral_parent("pelvis", "l") == "pelvis"
+    assert _resolve_bilateral_parent("torso", "r") == "torso"
+    assert _resolve_bilateral_parent("head", "l") == "head"
+
+
+def test_add_limb_side_simple_emits_link_and_joint() -> None:
+    """One-side helper emits exactly one link and one revolute joint."""
+    robot = ET.Element("robot")
+    spec = BodyModelSpec()
+    mass, length, radius = _seg(spec, "shank")
+    inertia = cylinder_inertia(mass, radius, length)
+
+    _add_limb_side_simple(
+        robot,
+        side="l",
+        sign=-1.0,
+        seg_name="shank",
+        parent_name="thigh",
+        mass=mass,
+        length=length,
+        radius=radius,
+        inertia=inertia,
+        parent_offset_z=-length,
+        parent_lateral_y=0.05,
+        coord_prefix="knee",
+        range_min=-2.0,
+        range_max=0.0,
+    )
+
+    links = robot.findall("link")
+    joints = robot.findall("joint")
+    assert len(links) == 1
+    assert links[0].get("name") == "shank_l"
+    assert len(joints) == 1
+    j = joints[0]
+    assert j.get("name") == "knee_l"
+    assert j.find("parent").get("link") == "thigh_l"  # type: ignore[union-attr]
+    # Left side: y offset is negative.
+    xyz = j.find("origin").get("xyz", "").split()  # type: ignore[union-attr]
+    assert float(xyz[1]) < 0
+
+
+def test_add_bilateral_limb_simple_creates_both_sides() -> None:
+    """Both left and right limbs are created, with matching joint names."""
+    robot = ET.Element("robot")
+    _add_bilateral_limb_simple(
+        robot,
+        BodyModelSpec(),
+        seg_name="shank",
+        parent_name="thigh",
+        parent_offset_z=-0.4,
+        parent_lateral_y=0.05,
+        coord_prefix="knee",
+        range_min=-2.0,
+        range_max=0.0,
+    )
+    link_names = {link.get("name") for link in robot.findall("link")}
+    joint_names = {j.get("name") for j in robot.findall("joint")}
+    assert {"shank_l", "shank_r"}.issubset(link_names)
+    assert {"knee_l", "knee_r"}.issubset(joint_names)
+
+
+def test_add_bilateral_limb_simple_symmetric_y_offset() -> None:
+    """Left joint has negative y origin; right joint has positive y origin."""
+    robot = ET.Element("robot")
+    _add_bilateral_limb_simple(
+        robot,
+        BodyModelSpec(),
+        seg_name="shank",
+        parent_name="thigh",
+        parent_offset_z=-0.4,
+        parent_lateral_y=0.05,
+        coord_prefix="knee",
+        range_min=-2.0,
+        range_max=0.0,
+    )
+    left = robot.find("joint[@name='knee_l']")
+    right = robot.find("joint[@name='knee_r']")
+    assert left is not None and right is not None
+    lxyz = left.find("origin").get("xyz", "").split()  # type: ignore[union-attr]
+    rxyz = right.find("origin").get("xyz", "").split()  # type: ignore[union-attr]
+    assert float(lxyz[1]) == pytest.approx(-float(rxyz[1]))

--- a/tests/unit/test_cli_helpers.py
+++ b/tests/unit/test_cli_helpers.py
@@ -1,0 +1,70 @@
+"""Unit tests for the argument-parser helpers introduced by A-N Refresh 2026-04-14.
+
+Issue #133 called out ``__main__.main`` as oversized; the subsequent
+``_create_parser`` has also grown.  This module covers the decomposition
+into ``_add_exercise_argument`` / ``_add_anthropometry_arguments`` /
+``_add_output_arguments`` so each argument group is independently testable.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pytest
+
+from pinocchio_models import __main__ as cli
+from pinocchio_models.shared.constants import VALID_EXERCISE_NAMES
+
+
+def test_add_exercise_argument_accepts_known_and_all() -> None:
+    """Known exercise names and the ``all`` keyword parse successfully."""
+    p = argparse.ArgumentParser()
+    cli._add_exercise_argument(p)
+    known = sorted(VALID_EXERCISE_NAMES)[0]
+    assert p.parse_args([known]).exercise == known
+    assert p.parse_args(["all"]).exercise == "all"
+
+
+def test_add_exercise_argument_rejects_unknown() -> None:
+    """An unknown exercise name fails at argparse level (SystemExit)."""
+    p = argparse.ArgumentParser()
+    cli._add_exercise_argument(p)
+    with pytest.raises(SystemExit):
+        p.parse_args(["not_an_exercise"])
+
+
+def test_add_anthropometry_arguments_defaults() -> None:
+    """Defaults come through as documented: 80 kg / 1.75 m / 0 kg plates."""
+    p = argparse.ArgumentParser()
+    cli._add_anthropometry_arguments(p)
+    ns = p.parse_args([])
+    assert ns.mass == pytest.approx(80.0)
+    assert ns.height == pytest.approx(1.75)
+    assert ns.plates == pytest.approx(0.0)
+
+
+def test_add_output_arguments_defaults_and_flags() -> None:
+    """``--output-dir`` yields a Path; ``-v`` sets ``verbose=True``."""
+    p = argparse.ArgumentParser()
+    cli._add_output_arguments(p)
+    ns = p.parse_args([])
+    assert ns.output_dir is None
+    assert ns.verbose is False
+    ns2 = p.parse_args(["--output-dir", "/tmp/out", "-v"])
+    assert ns2.output_dir == Path("/tmp/out")
+    assert ns2.verbose is True
+
+
+def test_create_parser_composes_all_groups() -> None:
+    """End-to-end: the composed parser accepts one command from each group."""
+    p = cli._create_parser()
+    known = sorted(VALID_EXERCISE_NAMES)[0]
+    ns = p.parse_args(
+        [known, "--mass", "70", "--height", "1.7", "--plates", "10", "-v"]
+    )
+    assert ns.exercise == known
+    assert ns.mass == pytest.approx(70.0)
+    assert ns.height == pytest.approx(1.7)
+    assert ns.plates == pytest.approx(10.0)
+    assert ns.verbose is True


### PR DESCRIPTION
## Summary

Addresses the next tier of oversized functions under issue #133.
The five named P1 functions (``get_initial_configuration``,
``ensure_valid_urdf``, ``get_exercise_contacts``, ``__main__.main``,
``interpolate_phases``) were already decomposed by PR #134/#135 and
now measure under the 40-LOC threshold.  This batch attacks the _next_
tier surfaced by a fresh LOC audit, plus extracts DRY helpers with
single-responsibility semantics.

## Items addressed

- [x] ``src/pinocchio_models/__main__.py::_create_parser`` (42 LOC) ->
  split into ``_add_exercise_argument``, ``_add_anthropometry_arguments``,
  ``_add_output_arguments``.
- [x] ``src/pinocchio_models/exercises/base.py::attach_barbell`` (49 LOC)
  -> extract ``_attach_shaft_to_left_hand`` and
  ``_attach_virtual_grip_right`` (both static, reusable).
- [x] ``src/pinocchio_models/shared/body/body_anthropometrics.py::``
  ``_add_bilateral_limb_simple`` (49 LOC) -> extract
  ``_resolve_bilateral_parent`` (DRY: single source of truth for the
  bilateral/central parent-naming rule) and ``_add_limb_side_simple``.

Each public call-site keeps its signature; internals are now composed
from focused helpers that each fit on one screen.

## Items deferred

- [ ] ``src/pinocchio_models/addons/pink/ik_solver.py`` (325 LOC monolith)
  and ``src/pinocchio_models/addons/crocoddyl/optimal_control.py``
  (324 LOC monolith) -- listed in #133 but require deeper design work
  (split into interfaces, re-tune import-ordering / try/except layer)
  and are deferred to a follow-up.
- [ ] ``src/pinocchio_models/shared/body/body_model.py`` (308 LOC) --
  cross-cuts with ongoing ``body_anthropometrics`` extraction; left for
  a dedicated PR once the bilateral/ndof helpers are further unified.

## Design notes

- TDD: new tests pin down each helper in isolation and verify the
  composed entry points still produce the original XML shape.
- DRY: ``_resolve_bilateral_parent`` centralizes the bilateral /
  central parent-link naming rule previously inlined in the loop.
- DbC: helper docstrings call out pre- and post-conditions explicitly
  (e.g. ``_attach_virtual_grip_right`` documents why we need a virtual
  link rather than a second parent).
- LOD: no new chain-call violations introduced.

## Test plan

- [x] ``python3 -m pytest -n auto --timeout=60`` -- 398 pass, 9 skipped.
  Pre-existing failure in ``test_get_initial_configuration`` (requires
  pinocchio; not introduced here).
- [x] ``ruff check`` clean.
- [x] ``ruff format --check`` clean.
- [ ] CI: ruff + mypy + coverage across Python 3.10/3.11/3.12.

Refs #133.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>