### PR TITLE
Reject non-finite positive contract inputs

### DIFF
--- a/src/pinocchio_models/shared/contracts/preconditions.py
+++ b/src/pinocchio_models/shared/contracts/preconditions.py
@@ -21,12 +21,14 @@ from numpy.typing import ArrayLike
 
 def require_positive(value: float, name: str) -> None:
     """Require *value* to be strictly positive."""
+    require_finite(value, name)
     if value <= 0:
         raise ValueError(f"{name} must be positive, got {value}")
 
 
 def require_non_negative(value: float, name: str) -> None:
     """Require *value* >= 0."""
+    require_finite(value, name)
     if value < 0:
         raise ValueError(f"{name} must be non-negative, got {value}")
 

--- a/tests/unit/shared/test_preconditions.py
+++ b/tests/unit/shared/test_preconditions.py
@@ -19,13 +19,21 @@ class TestRequirePositive:
     def test_accepts_positive(self) -> None:
         require_positive(1.0, "x")
 
-    def test_rejects_zero(self) -> None:
-        with pytest.raises(ValueError, match="must be positive"):
-            require_positive(0.0, "x")
-
-    def test_rejects_negative(self) -> None:
-        with pytest.raises(ValueError, match="must be positive"):
-            require_positive(-1.0, "x")
+    @pytest.mark.parametrize(
+        ("value", "message"),
+        [
+            (0.0, "must be positive"),
+            (-1.0, "must be positive"),
+            (float("nan"), "non-finite"),
+            (float("inf"), "non-finite"),
+            (float("-inf"), "non-finite"),
+        ],
+    )
+    def test_rejects_non_positive_or_non_finite(
+        self, value: float, message: str
+    ) -> None:
+        with pytest.raises(ValueError, match=message):
+            require_positive(value, "x")
 
 
 class TestRequireNonNegative:
@@ -35,9 +43,18 @@ class TestRequireNonNegative:
     def test_accepts_positive(self) -> None:
         require_non_negative(5.0, "x")
 
-    def test_rejects_negative(self) -> None:
-        with pytest.raises(ValueError, match="must be non-negative"):
-            require_non_negative(-0.1, "x")
+    @pytest.mark.parametrize(
+        ("value", "message"),
+        [
+            (-0.1, "must be non-negative"),
+            (float("nan"), "non-finite"),
+            (float("inf"), "non-finite"),
+            (float("-inf"), "non-finite"),
+        ],
+    )
+    def test_rejects_negative_or_non_finite(self, value: float, message: str) -> None:
+        with pytest.raises(ValueError, match=message):
+            require_non_negative(value, "x")
 
 
 class TestRequireUnitVector:


### PR DESCRIPTION
Fixes #146.

`require_positive()` and `require_non_negative()` now reject `NaN` and `±inf` before applying the sign check, matching the repo's contract style and the reference pattern from the sibling projects.

Tests:
- `python -m pytest tests/unit/shared`
- `ruff check src/pinocchio_models/shared/contracts/preconditions.py tests/unit/shared/test_preconditions.py`