### PR TITLE
refactor: split urdf link helper sections

### DIFF
--- a/src/pinocchio_models/shared/utils/urdf_helpers.py
+++ b/src/pinocchio_models/shared/utils/urdf_helpers.py
@@ -44,6 +44,70 @@ def vec3_str(x: float, y: float, z: float) -> str:
     return f"{x:.6f} {y:.6f} {z:.6f}"
 
 
+def _add_inertial(
+    link: ET.Element,
+    *,
+    mass: float,
+    origin_xyz: tuple[float, float, float],
+    origin_rpy: tuple[float, float, float],
+    ixx: float,
+    iyy: float,
+    izz: float,
+    ixy: float,
+    ixz: float,
+    iyz: float,
+) -> ET.Element:
+    """Append the inertial block for a URDF link."""
+    inertial = ET.SubElement(link, "inertial")
+    ET.SubElement(
+        inertial,
+        "origin",
+        xyz=vec3_str(*origin_xyz),
+        rpy=vec3_str(*origin_rpy),
+    )
+    ET.SubElement(inertial, "mass", value=f"{mass:.6f}")
+    ET.SubElement(
+        inertial,
+        "inertia",
+        ixx=f"{ixx:.6f}",
+        iyy=f"{iyy:.6f}",
+        izz=f"{izz:.6f}",
+        ixy=f"{ixy:.6f}",
+        ixz=f"{ixz:.6f}",
+        iyz=f"{iyz:.6f}",
+    )
+    return inertial
+
+
+def _add_visual(
+    link: ET.Element,
+    visual_geometry: ET.Element,
+    *,
+    visual_origin_rpy: tuple[float, float, float],
+) -> ET.Element:
+    """Append the optional visual block for a URDF link."""
+    visual = ET.SubElement(link, "visual")
+    ET.SubElement(
+        visual,
+        "origin",
+        xyz="0 0 0",
+        rpy=vec3_str(*visual_origin_rpy),
+    )
+    visual.append(visual_geometry)
+    return visual
+
+
+def _add_collision(
+    link: ET.Element,
+    collision_geometry: ET.Element,
+) -> ET.Element:
+    """Append the optional collision block for a URDF link."""
+    collision = ET.SubElement(link, "collision")
+    ET.SubElement(collision, "origin", xyz="0 0 0", rpy="0 0 0")
+    collision.append(collision_geometry)
+    return collision
+
+
 def add_link(
     robot: ET.Element,
     *,
@@ -71,40 +135,28 @@ def add_link(
     """
     link = ET.SubElement(robot, "link", name=name)
 
-    # Inertial
-    inertial = ET.SubElement(link, "inertial")
-    ET.SubElement(
-        inertial,
-        "origin",
-        xyz=vec3_str(*origin_xyz),
-        rpy=vec3_str(*origin_rpy),
-    )
-    ET.SubElement(inertial, "mass", value=f"{mass:.6f}")
-    ET.SubElement(
-        inertial,
-        "inertia",
-        ixx=f"{ixx:.6f}",
-        iyy=f"{iyy:.6f}",
-        izz=f"{izz:.6f}",
-        ixy=f"{ixy:.6f}",
-        ixz=f"{ixz:.6f}",
-        iyz=f"{iyz:.6f}",
+    _add_inertial(
+        link,
+        mass=mass,
+        origin_xyz=origin_xyz,
+        origin_rpy=origin_rpy,
+        ixx=ixx,
+        iyy=iyy,
+        izz=izz,
+        ixy=ixy,
+        ixz=ixz,
+        iyz=iyz,
     )
 
     if visual_geometry is not None:
-        visual = ET.SubElement(link, "visual")
-        ET.SubElement(
-            visual,
-            "origin",
-            xyz="0 0 0",
-            rpy=vec3_str(*visual_origin_rpy),
+        _add_visual(
+            link,
+            visual_geometry,
+            visual_origin_rpy=visual_origin_rpy,
         )
-        visual.append(visual_geometry)
 
     if collision_geometry is not None:
-        collision = ET.SubElement(link, "collision")
-        ET.SubElement(collision, "origin", xyz="0 0 0", rpy="0 0 0")
-        collision.append(collision_geometry)
+        _add_collision(link, collision_geometry)
 
     return link
 

--- a/tests/unit/shared/test_urdf_helpers.py
+++ b/tests/unit/shared/test_urdf_helpers.py
@@ -5,6 +5,9 @@ import xml.etree.ElementTree as ET
 import pytest
 
 from pinocchio_models.shared.utils.urdf_helpers import (
+    _add_collision,
+    _add_inertial,
+    _add_visual,
     _parse_initial_positions,
     add_fixed_joint,
     add_link,
@@ -51,6 +54,46 @@ class TestVec3Str:
 
 
 class TestAddLink:
+    def test_add_inertial_helper_formats_full_inertia_block(self) -> None:
+        link = ET.Element("link", name="body1")
+        inertial = _add_inertial(
+            link,
+            mass=5.0,
+            origin_xyz=(1.0, 2.0, 3.0),
+            origin_rpy=(0.1, 0.2, 0.3),
+            ixx=0.1,
+            iyy=0.2,
+            izz=0.3,
+            ixy=0.01,
+            ixz=0.02,
+            iyz=0.03,
+        )
+        assert inertial.find("origin").get("xyz") == "1.000000 2.000000 3.000000"  # type: ignore[union-attr]
+        assert inertial.find("origin").get("rpy") == "0.100000 0.200000 0.300000"  # type: ignore[union-attr]
+        assert inertial.find("mass").get("value") == "5.000000"  # type: ignore[union-attr]
+        inertia = inertial.find("inertia")
+        assert inertia is not None
+        assert inertia.get("ixy") == "0.010000"
+
+    def test_add_visual_helper_applies_visual_rotation(self) -> None:
+        link = ET.Element("link", name="body1")
+        visual = _add_visual(
+            link,
+            make_cylinder_geometry(0.05, 1.0),
+            visual_origin_rpy=(1.0, 0.0, 0.0),
+        )
+        assert visual.find("origin").get("rpy") == "1.000000 0.000000 0.000000"  # type: ignore[union-attr]
+        assert visual.find("geometry/cylinder") is not None
+
+    def test_add_collision_helper_uses_neutral_origin(self) -> None:
+        link = ET.Element("link", name="body1")
+        collision = _add_collision(link, make_box_geometry(1.0, 2.0, 3.0))
+        origin = collision.find("origin")
+        assert origin is not None
+        assert origin.get("xyz") == "0 0 0"
+        assert origin.get("rpy") == "0 0 0"
+        assert collision.find("geometry/box") is not None
+
     def test_creates_link_with_inertial(self) -> None:
         robot = ET.Element("robot", name="test")
         link = add_link(robot, name="body1", mass=5.0, ixx=0.1, iyy=0.2, izz=0.3)


### PR DESCRIPTION
## Summary
- split URDF link generation into inertial, visual, and collision helper sections
- add focused tests for each extracted helper while preserving add_link behavior

## Validation
- `TMPDIR=/tmp PYTHONPATH=src python3 -m pytest tests/unit/shared/test_urdf_helpers.py -q`
- `python3 -m ruff check src/pinocchio_models/shared/utils/urdf_helpers.py tests/unit/shared/test_urdf_helpers.py`
- `python3 -m black --check src/pinocchio_models/shared/utils/urdf_helpers.py tests/unit/shared/test_urdf_helpers.py`

Refs #133
