### PR TITLE
refactor(#133): split initial configuration helpers

### DIFF
--- a/src/pinocchio_models/shared/utils/urdf_helpers.py
+++ b/src/pinocchio_models/shared/utils/urdf_helpers.py
@@ -357,57 +357,16 @@ def _apply_initial_positions(
             q[joint.idx_q] = value
 
 
-def get_initial_configuration(model: Any, xml_str: str) -> Any:
-    """Build a Pinocchio configuration vector from ``initial_position`` metadata.
-
-    Reads the ``initial_position`` attributes written by
-    :func:`set_joint_default` and maps them onto the corresponding DOF
-    indices in *model*.  Joints without an ``initial_position`` attribute
-    receive the value from ``pin.neutral(model)``.
-
-    This is the **correct way** to apply an initial pose with Pinocchio —
-    read the metadata from the URDF string, then pass the resulting array
-    to ``pin.forwardKinematics``.
-
-    Parameters
-    ----------
-    model:
-        A ``pinocchio.Model`` built from the same URDF string, typically via::
-
-            model = pin.buildModelFromXML(urdf_str, pin.JointModelFreeFlyer())
-
-    xml_str:
-        The URDF XML string (as returned by ``ExerciseModelBuilder.build()``).
-
-    Returns
-    -------
-    numpy.ndarray
-        Configuration vector of shape ``(model.nq,)`` with FreeFlyer DOFs
-        at neutral and actuated joints set to their ``initial_position``
-        values.
-
-    Raises
-    ------
-    ImportError
-        If ``pinocchio`` or ``numpy`` are not installed.
-
-    Example
-    -------
-    ::
-
-        import pinocchio as pin
-        from pinocchio_models.exercises.squat.squat_model import build_squat_model
-        from pinocchio_models.shared.utils.urdf_helpers import get_initial_configuration
-
-        urdf_str = build_squat_model()
-        model = pin.buildModelFromXML(urdf_str, pin.JointModelFreeFlyer())
-        data = model.createData()
-
-        q0 = get_initial_configuration(model, urdf_str)
-        pin.forwardKinematics(model, data, q0)
-    """
-    pin = _import_pinocchio()
+def _build_initial_configuration(
+    pin: Any, model: Any, initial_positions: list[tuple[str, float]]
+) -> Any:
+    """Create a neutral configuration and overlay any scalar defaults."""
     q = pin.neutral(model)
-    initial_positions = _parse_initial_positions(xml_str)
     _apply_initial_positions(model, q, initial_positions)
     return q
+
+
+def get_initial_configuration(model: Any, xml_str: str) -> Any:
+    """Return a Pinocchio configuration seeded from URDF metadata."""
+    pin = _import_pinocchio()
+    return _build_initial_configuration(pin, model, _parse_initial_positions(xml_str))

--- a/tests/unit/shared/test_urdf_helpers.py
+++ b/tests/unit/shared/test_urdf_helpers.py
@@ -1,6 +1,7 @@
 """Tests for URDF XML generation helpers."""
 
 import xml.etree.ElementTree as ET
+from types import SimpleNamespace
 
 import pytest
 
@@ -8,6 +9,8 @@ from pinocchio_models.shared.utils.urdf_helpers import (
     _add_collision,
     _add_inertial,
     _add_visual,
+    _apply_initial_positions,
+    _build_initial_configuration,
     _parse_initial_positions,
     add_fixed_joint,
     add_link,
@@ -249,6 +252,51 @@ class TestSetJointDefault:
 
 class TestGetInitialConfiguration:
     """Tests for get_initial_configuration (requires pinocchio)."""
+
+    def test_build_initial_configuration_overlays_scalar_defaults(self) -> None:
+        fake_pin = SimpleNamespace(neutral=lambda model: [0.0, 0.0, 0.0])
+
+        class FakeModel:
+            joints = [
+                None,
+                SimpleNamespace(idx_q=0, nq=1),
+                SimpleNamespace(idx_q=1, nq=1),
+            ]
+
+            def getJointId(self, name: str) -> int:
+                return {"hip_l": 1, "knee_l": 2}[name]
+
+        q = _build_initial_configuration(
+            fake_pin,
+            FakeModel(),
+            [("hip_l", 1.25), ("knee_l", -0.5)],
+        )
+
+        assert q == [1.25, -0.5, 0.0]
+
+    def test_apply_initial_positions_skips_missing_and_multidof_joints(self) -> None:
+        class FakeModel:
+            joints = [
+                None,
+                SimpleNamespace(idx_q=0, nq=1),
+                SimpleNamespace(idx_q=1, nq=2),
+            ]
+
+            def getJointId(self, name: str) -> int:
+                if name == "hip_l":
+                    return 1
+                if name == "hip_l_flex":
+                    return 2
+                raise KeyError(name)
+
+        q = [0.0, 0.0]
+        _apply_initial_positions(
+            FakeModel(),
+            q,
+            [("hip_l", 0.75), ("hip_l_flex", 1.5), ("missing", 2.0)],
+        )
+
+        assert q == [0.75, 0.0]
 
     def test_returns_config_with_initial_positions(self) -> None:
         """Build a real squat model and verify initial config uses defaults."""


### PR DESCRIPTION
Refactor get_initial_configuration into a small helper-backed path and add focused unit coverage for the extracted configuration assembly behavior.\n\nReferences #133.