### PR TITLE
refactor: split contact spec validation

### DIFF
--- a/src/pinocchio_models/shared/contact/contact_model.py
+++ b/src/pinocchio_models/shared/contact/contact_model.py
@@ -131,6 +131,24 @@ def _barbell_contacts_for(exercise_name: str) -> list[ContactPoint] | None:
     ]
 
 
+def _validate_exercise_name(exercise_name: str) -> None:
+    """Validate contact lookup input before building a contact spec."""
+    if exercise_name not in VALID_EXERCISE_NAMES:
+        raise ValueError(
+            f"Unknown exercise '{exercise_name}'. "
+            f"Valid names: {sorted(VALID_EXERCISE_NAMES)}"
+        )
+
+
+def _build_contact_spec(exercise_name: str) -> ContactSpec:
+    """Assemble the contact spec for a validated exercise name."""
+    return ContactSpec(
+        foot_contacts=_both_feet_contacts(),
+        bench_contact=_bench_contact_for(exercise_name),
+        barbell_contacts=_barbell_contacts_for(exercise_name),
+    )
+
+
 def get_exercise_contacts(exercise_name: str, model: Any = None) -> ContactSpec:
     """Return contact specification for the given exercise.
 
@@ -155,14 +173,5 @@ def get_exercise_contacts(exercise_name: str, model: Any = None) -> ContactSpec:
     ValueError
         If *exercise_name* is not recognised.
     """
-    if exercise_name not in VALID_EXERCISE_NAMES:
-        raise ValueError(
-            f"Unknown exercise '{exercise_name}'. "
-            f"Valid names: {sorted(VALID_EXERCISE_NAMES)}"
-        )
-
-    return ContactSpec(
-        foot_contacts=_both_feet_contacts(),
-        bench_contact=_bench_contact_for(exercise_name),
-        barbell_contacts=_barbell_contacts_for(exercise_name),
-    )
+    _validate_exercise_name(exercise_name)
+    return _build_contact_spec(exercise_name)

--- a/tests/unit/shared/test_contact_model.py
+++ b/tests/unit/shared/test_contact_model.py
@@ -13,6 +13,8 @@ from pinocchio_models.shared.contact.contact_model import (
     _barbell_contacts_for,
     _bench_contact_for,
     _both_feet_contacts,
+    _build_contact_spec,
+    _validate_exercise_name,
     get_exercise_contacts,
 )
 
@@ -35,6 +37,16 @@ class TestExerciseContactHelpers:
             contacts = _barbell_contacts_for(name)
             assert contacts is not None
             assert {c.frame_name for c in contacts} == {"hand_l", "hand_r"}
+
+    def test_validate_exercise_name_rejects_unknown_name(self) -> None:
+        with pytest.raises(ValueError, match="Unknown exercise"):
+            _validate_exercise_name("not_a_lift")
+
+    def test_build_contact_spec_combines_shared_and_specific_contacts(self) -> None:
+        spec = _build_contact_spec("bench_press")
+        assert len(spec.foot_contacts) == 8
+        assert spec.bench_contact is not None
+        assert spec.barbell_contacts is None
 
 
 class TestContactPoint:


### PR DESCRIPTION
## Summary
- split exercise-name validation from contact-spec assembly
- add focused tests for validation and combined bench/contact spec behavior

## Validation
- `TMPDIR=/tmp PYTHONPATH=src python3 -m pytest tests/unit/shared/test_contact_model.py -q`
- `python3 -m ruff check src/pinocchio_models/shared/contact/contact_model.py tests/unit/shared/test_contact_model.py`
- `python3 -m black --check src/pinocchio_models/shared/contact/contact_model.py tests/unit/shared/test_contact_model.py`

Refs #133
