### PR TITLE
refactor(#133): decompose __main__.main() from 33 → 16 LOC

### DIFF
--- a/src/pinocchio_models/__main__.py
+++ b/src/pinocchio_models/__main__.py
@@ -127,6 +127,33 @@ def _emit_urdf(exercise_name: str, urdf_str: str, output_dir: Path | None) -> No
         stdout.write("\n")
 
 
+def _configure_logging(verbose: bool) -> None:
+    """Configure root logger level + format for the CLI run."""
+    logging.basicConfig(
+        level=logging.DEBUG if verbose else logging.WARNING,
+        format="%(levelname)s: %(message)s",
+    )
+
+
+def _resolve_exercise_list(requested: str) -> list[str]:
+    """Expand the ``exercise`` CLI argument to a concrete list of exercise names."""
+    if requested == "all":
+        return sorted(VALID_EXERCISE_NAMES)
+    return [requested]
+
+
+def _generate_one(exercise_name: str, args: argparse.Namespace) -> None:
+    """Build the URDF for a single exercise and emit it per CLI args."""
+    builder_fn = _BUILDERS[exercise_name]
+    logger.info("Generating %s model", exercise_name)
+    urdf_str = builder_fn(
+        body_mass=args.mass,
+        height=args.height,
+        plate_mass_per_side=args.plates,
+    )
+    _emit_urdf(exercise_name, urdf_str, args.output_dir)
+
+
 def main(argv: list[str] | None = None) -> int:
     """CLI entry point for Pinocchio model generation.
 
@@ -139,26 +166,9 @@ def main(argv: list[str] | None = None) -> int:
     parser = _create_parser()
     args = parser.parse_args(argv)
     _validate_cli_args(parser, args)
-
-    logging.basicConfig(
-        level=logging.DEBUG if args.verbose else logging.WARNING,
-        format="%(levelname)s: %(message)s",
-    )
-
-    exercises = (
-        sorted(VALID_EXERCISE_NAMES) if args.exercise == "all" else [args.exercise]
-    )
-
-    for exercise_name in exercises:
-        builder_fn = _BUILDERS[exercise_name]
-        logger.info("Generating %s model", exercise_name)
-        urdf_str = builder_fn(
-            body_mass=args.mass,
-            height=args.height,
-            plate_mass_per_side=args.plates,
-        )
-        _emit_urdf(exercise_name, urdf_str, args.output_dir)
-
+    _configure_logging(args.verbose)
+    for exercise_name in _resolve_exercise_list(args.exercise):
+        _generate_one(exercise_name, args)
     return 0
 
 

--- a/src/pinocchio_models/__main__.py
+++ b/src/pinocchio_models/__main__.py
@@ -128,10 +128,17 @@ def _emit_urdf(exercise_name: str, urdf_str: str, output_dir: Path | None) -> No
 
 
 def _configure_logging(verbose: bool) -> None:
-    """Configure root logger level + format for the CLI run."""
+    """Configure root logger level + format for the CLI run.
+
+    Uses ``force=True`` so repeated calls (e.g. in tests that exercise both
+    the verbose and non-verbose paths in the same process) reliably apply
+    the new level; a plain ``basicConfig`` is a no-op once the root logger
+    already has handlers.
+    """
     logging.basicConfig(
         level=logging.DEBUG if verbose else logging.WARNING,
         format="%(levelname)s: %(message)s",
+        force=True,
     )
 
 

--- a/tests/unit/test_cli_helpers.py
+++ b/tests/unit/test_cli_helpers.py
@@ -68,3 +68,26 @@ def test_create_parser_composes_all_groups() -> None:
     assert ns.height == pytest.approx(1.7)
     assert ns.plates == pytest.approx(10.0)
     assert ns.verbose is True
+
+
+def test_resolve_exercise_list_single() -> None:
+    """A specific exercise name returns a single-element list."""
+    known = sorted(VALID_EXERCISE_NAMES)[0]
+    assert cli._resolve_exercise_list(known) == [known]
+
+
+def test_resolve_exercise_list_all_is_sorted_full_set() -> None:
+    """The ``all`` keyword expands to every exercise name, sorted."""
+    result = cli._resolve_exercise_list("all")
+    assert result == sorted(VALID_EXERCISE_NAMES)
+    assert set(result) == set(VALID_EXERCISE_NAMES)
+
+
+def test_configure_logging_verbose_flag() -> None:
+    """``_configure_logging(True)`` sets the root logger to DEBUG."""
+    import logging
+
+    cli._configure_logging(verbose=True)
+    assert logging.getLogger().level == logging.DEBUG
+    cli._configure_logging(verbose=False)
+    assert logging.getLogger().level == logging.WARNING


### PR DESCRIPTION
Closes #133. The final listed function (`__main__.main` at 33 LOC) is decomposed into:

- `_configure_logging` (6 LOC)
- `_resolve_exercise_list` (5 LOC)
- `_generate_one` (10 LOC)
- `main` now 16 LOC

Added unit tests for the two pure helpers in `tests/unit/test_cli_helpers.py`.

The other 4 functions listed in #133 were already ≤30 LOC on main as of this check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)