### PR TITLE
refactor: split cli exercise generation helpers

### DIFF
--- a/src/pinocchio_models/__main__.py
+++ b/src/pinocchio_models/__main__.py
@@ -127,6 +127,30 @@ def _emit_urdf(exercise_name: str, urdf_str: str, output_dir: Path | None) -> No
         stdout.write("\n")
 
 
+def _selected_exercises(exercise: str) -> list[str]:
+    """Return concrete exercise names for a single exercise or ``all``."""
+    if exercise == "all":
+        return sorted(VALID_EXERCISE_NAMES)
+    return [exercise]
+
+
+def _build_urdf_for(
+    exercise_name: str,
+    *,
+    body_mass: float,
+    height: float,
+    plate_mass_per_side: float,
+) -> str:
+    """Build one exercise URDF from validated scalar CLI inputs."""
+    builder_fn = _BUILDERS[exercise_name]
+    logger.info("Generating %s model", exercise_name)
+    return builder_fn(
+        body_mass=body_mass,
+        height=height,
+        plate_mass_per_side=plate_mass_per_side,
+    )
+
+
 def main(argv: list[str] | None = None) -> int:
     """CLI entry point for Pinocchio model generation.
 
@@ -145,14 +169,9 @@ def main(argv: list[str] | None = None) -> int:
         format="%(levelname)s: %(message)s",
     )
 
-    exercises = (
-        sorted(VALID_EXERCISE_NAMES) if args.exercise == "all" else [args.exercise]
-    )
-
-    for exercise_name in exercises:
-        builder_fn = _BUILDERS[exercise_name]
-        logger.info("Generating %s model", exercise_name)
-        urdf_str = builder_fn(
+    for exercise_name in _selected_exercises(args.exercise):
+        urdf_str = _build_urdf_for(
+            exercise_name,
             body_mass=args.mass,
             height=args.height,
             plate_mass_per_side=args.plates,

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -7,7 +7,12 @@ from pathlib import Path
 
 import pytest
 
-from pinocchio_models.__main__ import _emit_urdf, main
+from pinocchio_models.__main__ import (
+    _build_urdf_for,
+    _emit_urdf,
+    _selected_exercises,
+    main,
+)
 
 
 class TestCLI:
@@ -78,3 +83,22 @@ class TestEmitUrdf:
         _emit_urdf("squat", '<robot name="r"/>', None)
         captured = capsys.readouterr()
         assert "<robot" in captured.out
+
+
+class TestCliHelpers:
+    def test_selected_exercises_expands_all(self) -> None:
+        exercises = _selected_exercises("all")
+        assert "back_squat" in exercises
+        assert "bench_press" in exercises
+
+    def test_selected_exercises_keeps_single_name(self) -> None:
+        assert _selected_exercises("deadlift") == ["deadlift"]
+
+    def test_build_urdf_for_returns_robot_xml(self) -> None:
+        urdf = _build_urdf_for(
+            "back_squat",
+            body_mass=80.0,
+            height=1.75,
+            plate_mass_per_side=0.0,
+        )
+        assert "<robot" in urdf


### PR DESCRIPTION
## Summary
- split Pinocchio CLI exercise selection and URDF generation into focused helpers
- add focused tests for all-expansion, single-exercise selection, and helper-built URDF output

## Validation
- `TMPDIR=/tmp PYTHONPATH=src python3 -m pytest tests/unit/test_cli.py -q`
- `python3 -m ruff check src/pinocchio_models/__main__.py tests/unit/test_cli.py`
- `python3 -m black --check src/pinocchio_models/__main__.py tests/unit/test_cli.py`

Refs #133
