### PR TITLE
Fix 2 MyPy type errors in test_exercise_objectives.py

### DIFF
--- a/tests/unit/optimization/test_exercise_objectives.py
+++ b/tests/unit/optimization/test_exercise_objectives.py
@@ -242,7 +242,7 @@ class TestTrajectoryConfig:
     )
     def test_negative_weight_raises(self, field: str, value: float) -> None:
         with pytest.raises(ValueError, match=field):
-            TrajectoryConfig(**{field: value})
+            TrajectoryConfig(**{field: value})  # type: ignore[arg-type]
 
     # Zero weights are allowed (disabling a cost term is valid)
     @pytest.mark.parametrize(
@@ -250,7 +250,7 @@ class TestTrajectoryConfig:
         ["control_weight", "state_weight", "terminal_weight", "balance_weight"],
     )
     def test_zero_weight_accepted(self, field: str) -> None:
-        cfg = TrajectoryConfig(**{field: 0.0})
+        cfg = TrajectoryConfig(**{field: 0.0})  # type: ignore[arg-type]
         assert getattr(cfg, field) == 0.0
 
     # Minimum valid values for strictly-positive fields


### PR DESCRIPTION
Fix MyPy type annotation errors by adding type ignores for dynamic kwargs unpacking.

## Changes
- Line 245: Add type: ignore[arg-type] for TrajectoryConfig(**{field: value})
- Line 253: Add type: ignore[arg-type] for TrajectoryConfig(**{field: 0.0})
- These lines dynamically construct kwargs that are valid at runtime but not statically verifiable

## Testing
- All 512 tests pass
- MyPy validation clean with no errors