### PR TITLE
fix(tests): skip hypothesis tests when hypothesis is not installed (#181)

### DIFF
--- a/tests/unit/shared/test_geometry_hypothesis.py
+++ b/tests/unit/shared/test_geometry_hypothesis.py
@@ -3,6 +3,10 @@
 from __future__ import annotations
 
 import numpy as np
+import pytest
+
+pytest.importorskip("hypothesis")
+
 from hypothesis import given, settings
 from hypothesis import strategies as st
 


### PR DESCRIPTION
## Summary

Fixes #181 by adding `pytest.importorskip("hypothesis")` at module level in `test_geometry_hypothesis.py`.

## Problem
The `test_geometry_hypothesis.py` test file would fail during pytest collection in environments where the `hypothesis` package is not installed, because the `from hypothesis import ...` statements at module level raise an `ImportError` before any test logic can run.

## Solution
Insert `pytest.importorskip("hypothesis")` before the `hypothesis` imports. This is the standard pytest mechanism for skipping an entire test module when an optional dependency is unavailable.

## Changes
- Added `import pytest` to the test file
- Added `pytest.importorskip("hypothesis")` before hypothesis imports
- All 14 hypothesis tests still pass when hypothesis IS installed (verified locally)

## Checklist
- [x] Tests pass locally
- [x] ruff linting passes
- [x] Commits follow conventional commit format