### PR TITLE
ci: prevent __pycache__ and .pyc pollution in CI (#203)

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -59,7 +59,20 @@ jobs:
         run: ruff format --check src scripts tests examples
 
       - run: pip install mypy types-PyYAML types-requests
-      - run: pip install -e .[dev]
+      - name: Install Package
+        env:
+          PYTHONDONTWRITEBYTECODE: 1
+        run: pip install -e .[dev]
+
+      - name: Verify Clean Working Tree
+        run: |
+          if git ls-files --others --exclude-standard | grep -qE '__pycache__|\.pyc$'; then
+            echo "::error::Untracked __pycache__ or .pyc files detected."
+            git ls-files --others --exclude-standard | grep -E '__pycache__|\.pyc$'
+            exit 1
+          fi
+          echo "Working tree is clean."
+
       - run: mypy src --config-file pyproject.toml
 
       - name: Verify No Placeholders
@@ -115,7 +128,19 @@ jobs:
           echo "$RUNNER_TEMP/ci-venv/bin" >> $GITHUB_PATH
 
       - name: Install Dependencies
+        env:
+          PYTHONDONTWRITEBYTECODE: 1
         run: pip install -e ".[dev]"
+
+      - name: Verify Clean Working Tree
+        run: |
+          # Ensure no untracked __pycache__ or *.pyc files remain
+          if git ls-files --others --exclude-standard | grep -qE '__pycache__|\.pyc$'; then
+            echo "::error::Untracked __pycache__ or .pyc files detected."
+            git ls-files --others --exclude-standard | grep -E '__pycache__|\.pyc$'
+            exit 1
+          fi
+          echo "Working tree is clean."
 
       - name: Run Test Suite
         run: |


### PR DESCRIPTION
## Summary

Fixes #203 by preventing `__pycache__` directories and `.pyc` files from being generated during CI and from polluting the working tree.

## Problem
The repository had 18 `__pycache__` directories and 35 `.pyc` files present in the working tree. While these were properly `.gitignore`d (not tracked by git), they indicated that Python bytecode was being generated during local development and CI runs, which can lead to stale cache issues and a dirty working tree.

## Changes
1. **Removed existing `__pycache__` and `.pyc` files** from the working tree
2. **Added `PYTHONDONTWRITEBYTECODE=1`** to both `pip install` steps in the CI workflow (quality-gate and tests jobs)
3. **Added "Verify Clean Working Tree" step** in both CI jobs that fails the build if any untracked `__pycache__` or `*.pyc` files are detected after installation

## Checklist
- [x] Working tree cleaned of __pycache__ and .pyc files
- [x] CI workflow updated with prevention and verification
- [x] Conventional commit format followed