### PR TITLE
deps: relax NumPy upper bound from <3.0.0 (closes #196)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -258,4 +258,5 @@ The repository is in active maintenance. Shared model generation is established,
 | 2026-04-06 | 1.0.0 | Initial repository specification for Pinocchio_Models. |
 | 2026-04-11 | 1.0.1 | Decomposed five oversized functions (#128) into single-purpose private helpers; behaviour preserved. |
 | 2026-04-11 | 1.0.2 | Split top-2 monolithic addon scripts (#129): ``optimal_control.py`` and ``ik_solver.py`` now delegate to focused builder/task/config submodules. Public API and module attributes preserved. |
+| 2026-04-27 | 1.0.4 | Removed the `numpy<3.0.0` upper bound in `pyproject.toml` dependencies. |
 | 2026-04-27 | 1.0.3 | Optimization: Cached formatting of floats to URDF strings. |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "numpy>=1.26.4,<3.0.0",
+    "numpy>=1.26.4",
     "matplotlib>=3.7.0",
 ]
 


### PR DESCRIPTION
NumPy 2.x is stable and the <3.0.0 cap blocks future security fixes.
Remove the upper bound so consumers can install newer NumPy releases.