### PR TITLE
ci(security): add SBOM generation with cyclonedx-bom

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -103,6 +103,17 @@ jobs:
         run: |
           bandit -r src/ -ll -ii --format txt 2>&1
 
+      - name: Generate SBOM
+        run: |
+          pip install cyclonedx-bom
+          cyclonedx-py -e -o sbom.json
+
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom
+          path: sbom.json
+
     needs: pick-runner
   tests:
     needs:

--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Generate SBOM
         run: |
           pip install cyclonedx-bom
-          cyclonedx-py -e -o sbom.json
+          cyclonedx-py environment -o sbom.json
 
       - name: Upload SBOM artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Generate SBOM
         run: |
           pip install cyclonedx-bom
-          cyclonedx-py environment -o sbom.json
+          cyclonedx-py environment -o sbom.json --output-format JSON
 
       - name: Upload SBOM artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Generates a CycloneDX SBOM from the editable install and uploads it as a CI artifact. This provides an inventory of dependencies for security auditing and supply-chain transparency.\n\nFixes #197