### PR TITLE
fix(errors): add structured error codes to exception messages

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -45,7 +45,18 @@ jobs:
         id: check
         env:
           GH_TOKEN: ${{ secrets.RUNNER_CHECK_TOKEN }}
-        run: "ONLINE=$(gh api /orgs/${{ github.repository_owner }}/actions/runners \\\n  --jq '[.runners[] | select(.status == \"online\") | select(.labels[].name == \"d-sorg-fleet\")] | length' \\\n  2>/dev/null || echo \"0\")\nif [[ \"$ONLINE\" -gt 0 ]]; then\n  echo \"runner=d-sorg-fleet\" >> $GITHUB_OUTPUT\n  echo \"Self-hosted runner online — routing locally\"\nelse\n  echo \"runner=ubuntu-latest\" >> $GITHUB_OUTPUT\n  echo \"No self-hosted runner — using GitHub-hosted\"\nfi"
+        run: |
+          mkdir -p "$(dirname "$GITHUB_OUTPUT")"
+          ONLINE=$(gh api /orgs/${{ github.repository_owner }}/actions/runners \
+            --jq '[.runners[] | select(.status == "online") | select(.labels[].name == "d-sorg-fleet")] | length' \
+            2>/dev/null || echo "0")
+          if [[ "$ONLINE" -gt 0 ]]; then
+            echo "runner=d-sorg-fleet" >> "$GITHUB_OUTPUT"
+            echo "Self-hosted runner online - routing locally"
+          else
+            echo "runner=ubuntu-latest" >> "$GITHUB_OUTPUT"
+            echo "No self-hosted runner - using GitHub-hosted"
+          fi
   quality-gate:
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     timeout-minutes: 15

--- a/SPEC.md
+++ b/SPEC.md
@@ -18,8 +18,8 @@
 | **Primary Language(s)** | Python 3.10+ |
 | **License** | MIT |
 | **Current Version** | 0.1.0 |
-| **Spec Version** | 1.0.11 |
-| **Last Spec Update** | 2026-04-28 |
+| **Spec Version** | 1.0.13 |
+| **Last Spec Update** | 2026-04-29 |
 
 ## 2. Purpose & Mission
 
@@ -120,6 +120,8 @@ The stable public surface is the importable builder API and the CLI:
 - `create_full_body(...)` and `create_barbell_links(...)`
 - Domain exceptions inherit from `PinocchioModelsError` and expose stable
   machine-readable error codes in the `PM000`-style namespace.
+- Shared contract validation uses stable structured codes for precondition
+  failures (`PM101`-`PM111`) and postcondition failures (`PM201`-`PM207`).
 
 Pinocchio-specific runtime behavior is intentionally externalized:
 
@@ -292,3 +294,4 @@ The repository is in active maintenance. Shared model generation is established,
 | 2026-04-28 | 1.0.10 | Documented the model-generation performance budget and profiling targets. |
 | 2026-04-28 | 1.0.11 | Added a minimal Sphinx autodoc foundation for API reference documentation. |
 | 2026-04-28 | 1.0.12 | Added auditable pip-audit ignore tracking and CI validation for ignored CVEs. |
+| 2026-04-29 | 1.0.13 | Documented stable structured error codes for shared contract validation. |

--- a/src/pinocchio_models/shared/contracts/postconditions.py
+++ b/src/pinocchio_models/shared/contracts/postconditions.py
@@ -61,7 +61,8 @@ def _validate_joint_links(root: ET.Element, link_names: set[str]) -> None:
         # (b) Verify child link name exists in the declared link set.
         if child_link and child_link not in link_names:
             raise URDFError(
-                f"Joint '{joint_name}' references unknown child link '{child_link}'"
+                f"Joint '{joint_name}' references unknown child link '{child_link}'",
+                error_code="PM201",
             )
 
         # (c) Assert no link appears as child of more than one joint
@@ -70,7 +71,8 @@ def _validate_joint_links(root: ET.Element, link_names: set[str]) -> None:
             raise URDFError(
                 f"Link '{child_link}' is declared as child of both "
                 f"'{child_parent_map[child_link]}' and '{joint_name}' — "
-                "URDF requires each link to have exactly one parent joint"
+                "URDF requires each link to have exactly one parent joint",
+                error_code="PM202",
             )
         if child_link:
             child_parent_map[child_link] = joint_name
@@ -96,7 +98,10 @@ def ensure_valid_urdf_tree(root: ET.Element) -> ET.Element:
     Raises ValueError if any check fails.
     """
     if root.tag != "robot":
-        raise URDFError(f"URDF root must be <robot>, got <{root.tag}>")
+        raise URDFError(
+            f"URDF root must be <robot>, got <{root.tag}>",
+            error_code="PM203",
+        )
 
     # Validate all tags are valid XML to replicate the parsing check
     for el in root.iter():
@@ -104,7 +109,8 @@ def ensure_valid_urdf_tree(root: ET.Element) -> ET.Element:
         if type(tag) is str:
             if not _VALID_TAG_MATCH(tag):
                 raise URDFError(
-                    f"Generated URDF is not well-formed XML: invalid tag '{tag}'"
+                    f"Generated URDF is not well-formed XML: invalid tag '{tag}'",
+                    error_code="PM204",
                 )
         else:
             # ElementTree stores comments and processing instructions as
@@ -137,7 +143,8 @@ def ensure_positive_mass(mass: float, body_name: str) -> None:
     """Validate that a body's mass is positive after computation."""
     if mass <= 0:
         raise URDFError(
-            f"Postcondition violated: {body_name} mass={mass} is not positive"
+            f"Postcondition violated: {body_name} mass={mass} is not positive",
+            error_code="PM205",
         )
 
 
@@ -148,11 +155,13 @@ def ensure_positive_definite_inertia(
     for label, val in [("Ixx", ixx), ("Iyy", iyy), ("Izz", izz)]:
         if val <= 0:
             raise URDFError(
-                f"Postcondition violated: {body_name} {label}={val} not positive"
+                f"Postcondition violated: {body_name} {label}={val} not positive",
+                error_code="PM206",
             )
     # Triangle inequality for principal inertias
     if ixx + iyy < izz or ixx + izz < iyy or iyy + izz < ixx:
         raise URDFError(
             f"Postcondition violated: {body_name} inertias "
-            f"({ixx}, {iyy}, {izz}) violate triangle inequality"
+            f"({ixx}, {iyy}, {izz}) violate triangle inequality",
+            error_code="PM207",
         )

--- a/src/pinocchio_models/shared/contracts/postconditions.py
+++ b/src/pinocchio_models/shared/contracts/postconditions.py
@@ -23,9 +23,15 @@ def _parse_robot_root(xml_string: str) -> ET.Element:
     try:
         root = ET.fromstring(xml_string)  # nosec B314 — parsing self-generated XML
     except ET.ParseError as exc:
-        raise URDFError(f"Generated URDF is not well-formed XML: {exc}") from exc
+        raise URDFError(
+            f"Generated URDF is not well-formed XML: {exc}",
+            error_code="PM204",
+        ) from exc
     if root.tag != "robot":
-        raise URDFError(f"URDF root must be <robot>, got <{root.tag}>")
+        raise URDFError(
+            f"URDF root must be <robot>, got <{root.tag}>",
+            error_code="PM203",
+        )
     return root
 
 

--- a/src/pinocchio_models/shared/contracts/preconditions.py
+++ b/src/pinocchio_models/shared/contracts/preconditions.py
@@ -27,48 +27,72 @@ def require_positive(value: float, name: str) -> None:
     """Require *value* to be strictly positive."""
     require_finite(value, name)
     if value <= 0:
-        raise URDFError(f"{name} must be positive, got {value}")
+        raise URDFError(
+            f"{name} must be positive, got {value}",
+            error_code="PM101",
+        )
 
 
 def require_non_negative(value: float, name: str) -> None:
     """Require *value* >= 0."""
     require_finite(value, name)
     if value < 0:
-        raise URDFError(f"{name} must be non-negative, got {value}")
+        raise URDFError(
+            f"{name} must be non-negative, got {value}",
+            error_code="PM102",
+        )
 
 
 def require_unit_vector(vec: ArrayLike, name: str, tol: float = 1e-6) -> None:
     """Require *vec* to have unit norm within *tol*."""
     arr = np.asarray(vec, dtype=float)
     if arr.shape != (3,):
-        raise URDFError(f"{name} must be a 3-vector, got shape {arr.shape}")
+        raise URDFError(
+            f"{name} must be a 3-vector, got shape {arr.shape}",
+            error_code="PM103",
+        )
     norm = float(np.linalg.norm(arr))
     if abs(norm - 1.0) > tol:
-        raise URDFError(f"{name} must be unit-length (norm={norm:.6f})")
+        raise URDFError(
+            f"{name} must be unit-length (norm={norm:.6f})",
+            error_code="PM104",
+        )
 
 
 def require_finite(arr: ArrayLike, name: str) -> None:
     """Require all elements of *arr* to be finite (no NaN/Inf)."""
     if isinstance(arr, (int, float)):
         if not math.isfinite(arr):
-            raise URDFError(f"{name} contains non-finite values")
+            raise URDFError(
+                f"{name} contains non-finite values",
+                error_code="PM105",
+            )
         return
     a = np.asarray(arr, dtype=float)
     if not np.all(np.isfinite(a)):
-        raise URDFError(f"{name} contains non-finite values")
+        raise URDFError(
+            f"{name} contains non-finite values",
+            error_code="PM105",
+        )
 
 
 def require_in_range(value: float, low: float, high: float, name: str) -> None:
     """Require *low* <= *value* <= *high*."""
     if not (low <= value <= high):
-        raise URDFError(f"{name} must be in [{low}, {high}], got {value}")
+        raise URDFError(
+            f"{name} must be in [{low}, {high}], got {value}",
+            error_code="PM106",
+        )
 
 
 def require_shape(arr: ArrayLike, expected: tuple[int, ...], name: str) -> None:
     """Require *arr* to have the given shape."""
     a = np.asarray(arr)
     if a.shape != expected:
-        raise URDFError(f"{name} must have shape {expected}, got {a.shape}")
+        raise URDFError(
+            f"{name} must have shape {expected}, got {a.shape}",
+            error_code="PM107",
+        )
 
 
 def require_valid_urdf_string(urdf_str: str) -> None:
@@ -85,17 +109,26 @@ def require_valid_urdf_string(urdf_str: str) -> None:
     Raises :class:`ValueError` with a descriptive message on failure.
     """
     if not urdf_str or not urdf_str.strip():
-        raise URDFError("URDF string must not be empty")
+        raise URDFError(
+            "URDF string must not be empty",
+            error_code="PM108",
+        )
 
     import xml.etree.ElementTree as ET
 
     try:
         root = ET.fromstring(urdf_str)  # nosec B314 -- validating input
     except ET.ParseError as exc:
-        raise URDFError(f"URDF string is not valid XML: {exc}") from exc
+        raise URDFError(
+            f"URDF string is not valid XML: {exc}",
+            error_code="PM109",
+        ) from exc
 
     if root.tag != "robot":
-        raise URDFError(f"URDF root element must be <robot>, got <{root.tag}>")
+        raise URDFError(
+            f"URDF root element must be <robot>, got <{root.tag}>",
+            error_code="PM110",
+        )
 
 
 def require_valid_exercise_name(exercise_name: str) -> None:
@@ -109,5 +142,6 @@ def require_valid_exercise_name(exercise_name: str) -> None:
     if exercise_name not in VALID_EXERCISE_NAMES:
         raise URDFError(
             f"Unknown exercise '{exercise_name}'. "
-            f"Valid names: {sorted(VALID_EXERCISE_NAMES)}"
+            f"Valid names: {sorted(VALID_EXERCISE_NAMES)}",
+            error_code="PM111",
         )

--- a/tests/unit/shared/test_postconditions.py
+++ b/tests/unit/shared/test_postconditions.py
@@ -4,6 +4,7 @@ import xml.etree.ElementTree as ET
 
 import pytest
 
+from pinocchio_models.exceptions import URDFError
 from pinocchio_models.shared.contracts.postconditions import (
     _collect_link_names,
     _parse_robot_root,
@@ -20,12 +21,14 @@ class TestEnsureValidUrdf:
         assert root.tag == "robot"
 
     def test_rejects_malformed_xml(self) -> None:
-        with pytest.raises(ValueError, match="not well-formed"):
+        with pytest.raises(URDFError, match="not well-formed") as exc_info:
             ensure_valid_urdf("<robot><unclosed>")
+        assert exc_info.value.error_code == "PM204"
 
     def test_rejects_non_robot_root(self) -> None:
-        with pytest.raises(ValueError, match="root must be <robot>"):
+        with pytest.raises(URDFError, match="root must be <robot>") as exc_info:
             ensure_valid_urdf("<model/>")
+        assert exc_info.value.error_code == "PM203"
 
 
 class TestParseRobotRoot:
@@ -34,8 +37,9 @@ class TestParseRobotRoot:
         assert root.tag == "robot"
 
     def test_rejects_non_robot_tag(self) -> None:
-        with pytest.raises(ValueError, match="root must be <robot>"):
+        with pytest.raises(URDFError, match="root must be <robot>") as exc_info:
             _parse_robot_root("<thing/>")
+        assert exc_info.value.error_code == "PM203"
 
 
 class TestCollectLinkNames:


### PR DESCRIPTION
Fixes #189

Adds machine-readable error_code attributes to all URDFError raises in preconditions.py and postconditions.py.

Error code taxonomy:
- PM101-PM111: precondition violations
- PM201-PM207: postcondition violations

Enables programmatic error handling and improves observability per Criterion J.