### PR TITLE
fix: enforce cyclomatic complexity (McCabe) in CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ target-version = "py310"
 select = [
     "E", "F", "I", "UP", "B", "T201", "SIM",
     "C4", "PIE", "PLE", "FURB", "RSE", "LOG",
-    "PERF", "RET",
+    "PERF", "RET", "C90",
 ]
 ignore = [
     "E501",
@@ -86,6 +86,9 @@ ignore = [
     "PERF203",
     "PERF401",
 ]
+
+[tool.ruff.lint.mccabe]
+max-complexity = 10
 
 [tool.ruff.lint.per-file-ignores]
 "scripts/**" = ["T201"]


### PR DESCRIPTION
Addresses issue #187 by enabling the C90 (McCabe) complexity check in Ruff with a threshold of 10.