### PR TITLE
chore(testing): adopt fleet testing standards Phase 1 (#278)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,1 +1,28 @@
-"""Root conftest for pytest."""
+"""Root conftest for pytest.
+
+Enforces fleet testing standards
+(Repository_Management/docs/FLEET_TESTING_STANDARDS.md §5):
+- C-extension thread-safety env vars are pinned BEFORE any heavy import.
+- Headless backends (matplotlib / Qt) are pinned BEFORE any heavy import.
+"""
+
+from __future__ import annotations
+
+# ---------------------------------------------------------------------------
+# Fleet Testing Standards §5 -- env vars MUST be set before heavy imports.
+# ---------------------------------------------------------------------------
+import os
+
+# C-extension thread safety. Many "xdist worker crashed" failures
+# come from MKL/OpenBLAS forking under xdist. Pin to single-threaded
+# for tests; production code can re-thread itself if it needs to.
+os.environ.setdefault("OMP_NUM_THREADS", "1")
+os.environ.setdefault("OPENBLAS_NUM_THREADS", "1")
+os.environ.setdefault("MKL_NUM_THREADS", "1")
+os.environ.setdefault("NUMEXPR_NUM_THREADS", "1")
+
+# matplotlib headless backend, set before any matplotlib import.
+os.environ.setdefault("MPLBACKEND", "Agg")
+
+# Qt headless backend, for repos that import PyQt/PySide indirectly.
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,19 +101,54 @@ ignore_missing_imports = true
 check_untyped_defs = true
 disallow_untyped_defs = true
 
+# ---------------------------------------------------------------------------
+# Fleet Testing Standards (see Repository_Management/docs/FLEET_TESTING_STANDARDS.md §2)
+# Tier: Data / fixtures repo -> no coverage gate added by Phase 1.
+# ---------------------------------------------------------------------------
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 pythonpath = [".", "src"]
 python_files = "test_*.py"
 python_classes = "Test*"
 python_functions = "test_*"
-addopts = "-ra -q --strict-markers --strict-config --durations=20 -n auto --dist loadscope"
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
+timeout = 60
+timeout_method = "thread"
+
+# Default lane: fast, deterministic, offline.
+addopts = """
+  -ra
+  -q
+  --strict-markers
+  --strict-config
+  --durations=20
+  -n auto
+  --dist loadscope
+  -m "not slow and not live_simulation and not e2e and not requires_network"
+"""
+
 markers = [
-    "slow: marks tests as slow",
-    "integration: marks tests as integration tests",
-    "unit: marks tests as unit tests",
-    "requires_pinocchio: tests requiring pinocchio package",
-    "benchmark: marks tests as benchmarks",
+    # ---- tier markers ----
+    "unit: pure logic, fully mocked, < 100 ms wall-clock",
+    "integration: cross-module / file-system / process boundaries, < 5 s",
+    "e2e: full-stack smoke tests; nightly + release gate only",
+    "slow: > 1 s wall-clock; deselect with -m 'not slow'",
+    "live_simulation: requires a real physics / math engine; deselect by default",
+
+    # ---- environment markers ----
+    "requires_network: needs real outbound network; deselect by default",
+    "requires_gpu: needs CUDA / Metal / ROCm",
+    "requires_gl: needs OpenGL or a display",
+    "headless_safe: verified under QT_QPA_PLATFORM=offscreen",
+
+    # ---- per-engine markers ----
+    "requires_pinocchio: skip when pinocchio is the stub PyPI wheel",
+
+    # ---- workflow markers ----
+    "serial: must run with -n 0 (xdist parallel breaks this test)",
+    "benchmark: deterministic perf smoke; not a primary correctness gate",
+    "smoke: release-blocking smoke; subset of e2e",
 ]
 filterwarnings = [
     "ignore::DeprecationWarning",


### PR DESCRIPTION
## Summary

Phase 1 of fleet testing alignment for Pinocchio_Models (data/fixtures tier — no coverage gate added in Phase 1).

- Additive §2 merge into `pyproject.toml`: adds `asyncio_mode`, `asyncio_default_fixture_loop_scope`, `timeout=60`, `timeout_method=thread`, and the default-lane exclusion `-m "not slow and not live_simulation and not e2e and not requires_network"`. Existing `-n auto --dist loadscope` and `[tool.coverage.report]` are preserved.
- Expands markers to the canonical fleet set (tier / env / per-engine / workflow), including `requires_pinocchio` for the stub-wheel skip path.
- Adds §5 thread-safety / headless env block to root `conftest.py` (OMP/OPENBLAS/MKL/NUMEXPR=1, `MPLBACKEND=Agg`, `QT_QPA_PLATFORM=offscreen`), set BEFORE any heavy import.

Refs: `Repository_Management/docs/FLEET_TESTING_STANDARDS.md` §2, §5
EPIC: D-sorganization/Repository_Management#1140
Closes #278

## Test plan

- [x] `pytest --collect-only -q` succeeds (543 collected, 5 deselected by default lane).
- [ ] CI green on the standard pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>