### PR TITLE
feat: publish model_pack discovery surface for UpstreamDrift (#282)

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -206,6 +206,10 @@ jobs:
           fi
           echo "Working tree is clean."
 
+      - name: Verify model_pack entry-point surface (issue #282)
+        run: |
+          python3 -c "from pinocchio_models.model_pack import resolve, manifest, list_exercises; resolve(); manifest(); list_exercises()"
+
       - name: Run Test Suite
         run: |
           python3 -m pytest \

--- a/README.md
+++ b/README.md
@@ -2,6 +2,27 @@
 
 Pinocchio-based multibody dynamics simulation for five classical barbell exercises, with optional integration for Gepetto-viewer visualization, Pink inverse kinematics, and Crocoddyl optimal control.
 
+## Used by UpstreamDrift
+
+This repository publishes a `model_pack/v1` manifest (`model_pack.yaml` at
+the repo root) and a `biomech.model_pack` entry point
+(`pinocchio_models.model_pack`) so the UpstreamDrift launcher can discover
+and host this repo's exercise content. See the umbrella tracking issue
+[D-sorganization/UpstreamDrift#5179](https://github.com/D-sorganization/UpstreamDrift/issues/5179).
+
+```python
+from pinocchio_models.model_pack import resolve, manifest, list_exercises
+
+resolve()         # absolute path to the installed exercises directory
+manifest()        # parsed model_pack.yaml as a dict
+list_exercises()  # ['squat', 'deadlift', ...]
+```
+
+```bash
+python -m pinocchio_models --list-exercises
+python -m pinocchio_models --exercise gait --export /tmp/gait.urdf
+```
+
 ## Exercises
 
 | Exercise       | Description                                            |

--- a/model_pack.yaml
+++ b/model_pack.yaml
@@ -1,0 +1,27 @@
+schema: model_pack/v1
+repo: Pinocchio_Models
+package: pinocchio_models
+engine: pinocchio
+engine_version: ">=2.7"
+anthropometrics: winter_2009
+format: urdf
+addons:
+  gepetto: optional
+  pink: optional
+  crocoddyl: optional
+models_root: src/pinocchio_models/exercises
+exercises:
+  - id: squat
+    path: src/pinocchio_models/exercises/squat
+  - id: deadlift
+    path: src/pinocchio_models/exercises/deadlift
+  - id: bench_press
+    path: src/pinocchio_models/exercises/bench_press
+  - id: snatch
+    path: src/pinocchio_models/exercises/snatch
+  - id: clean_and_jerk
+    path: src/pinocchio_models/exercises/clean_and_jerk
+  - id: gait
+    path: src/pinocchio_models/exercises/gait
+  - id: sit_to_stand
+    path: src/pinocchio_models/exercises/sit_to_stand

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
 dependencies = [
     "numpy>=1.26.4",
     "matplotlib>=3.7.0",
+    "pyyaml>=6.0.0",
 ]
 
 [project.optional-dependencies]
@@ -59,6 +60,9 @@ dev = [
 [project.scripts]
 pinocchio-models = "pinocchio_models.__main__:main"
 
+[project.entry-points."biomech.model_pack"]
+pinocchio_models = "pinocchio_models.model_pack"
+
 [project.urls]
 Homepage = "https://github.com/D-sorganization/Pinocchio_Models"
 Repository = "https://github.com/D-sorganization/Pinocchio_Models"
@@ -69,6 +73,18 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/pinocchio_models", "src/robotics_contracts"]
+
+[tool.hatch.build.targets.wheel.force-include]
+"model_pack.yaml" = "pinocchio_models/model_pack.yaml"
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "src/pinocchio_models",
+    "src/robotics_contracts",
+    "model_pack.yaml",
+    "README.md",
+    "LICENSE",
+]
 
 [tool.ruff]
 line-length = 88

--- a/src/pinocchio_models/__main__.py
+++ b/src/pinocchio_models/__main__.py
@@ -249,9 +249,7 @@ def _emit_list_exercises() -> int:
     return 0
 
 
-def _output_path_for(
-    exercise_name: str, args: argparse.Namespace
-) -> str | None:
+def _output_path_for(exercise_name: str, args: argparse.Namespace) -> str | None:
     """Return the on-disk path the URDF was (or would be) written to, or ``None``."""
     if args.export is not None:
         return str(args.export)
@@ -260,9 +258,7 @@ def _output_path_for(
     return None
 
 
-def _emit_exercise(
-    exercise_name: str, urdf_str: str, args: argparse.Namespace
-) -> None:
+def _emit_exercise(exercise_name: str, urdf_str: str, args: argparse.Namespace) -> None:
     """Write *urdf_str* to disk or stdout based on CLI flags."""
     if args.export is not None:
         _write_export(args.export, urdf_str)

--- a/src/pinocchio_models/__main__.py
+++ b/src/pinocchio_models/__main__.py
@@ -249,6 +249,57 @@ def _emit_list_exercises() -> int:
     return 0
 
 
+def _output_path_for(
+    exercise_name: str, args: argparse.Namespace
+) -> str | None:
+    """Return the on-disk path the URDF was (or would be) written to, or ``None``."""
+    if args.export is not None:
+        return str(args.export)
+    if args.output_dir is not None:
+        return str(args.output_dir / f"{exercise_name}.urdf")
+    return None
+
+
+def _emit_exercise(
+    exercise_name: str, urdf_str: str, args: argparse.Namespace
+) -> None:
+    """Write *urdf_str* to disk or stdout based on CLI flags."""
+    if args.export is not None:
+        _write_export(args.export, urdf_str)
+    elif not args.json:
+        _emit_urdf(exercise_name, urdf_str, args.output_dir)
+
+
+def _build_and_collect(
+    canonical: str, args: argparse.Namespace
+) -> list[dict[str, object]]:
+    """Build URDFs for the selection and return JSON-result rows."""
+    results: list[dict[str, object]] = []
+    for exercise_name in _selected_exercises(canonical):
+        urdf_str = _build_urdf_for(
+            exercise_name,
+            body_mass=args.mass,
+            height=args.height,
+            plate_mass_per_side=args.plates,
+        )
+        _emit_exercise(exercise_name, urdf_str, args)
+        if args.json:
+            results.append(
+                {
+                    "exercise": exercise_name,
+                    "urdf": urdf_str,
+                    "path": _output_path_for(exercise_name, args),
+                    "parameters": {
+                        "mass": args.mass,
+                        "height": args.height,
+                        "plates": args.plates,
+                    },
+                    "success": True,
+                }
+            )
+    return results
+
+
 def main(argv: list[str] | None = None) -> int:
     """CLI entry point for Pinocchio model generation.
 
@@ -280,42 +331,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.export is not None and canonical == "all":
         parser.error("--export requires a single exercise (got 'all')")
 
-    results: list[dict[str, object]] = []
-    for exercise_name in _selected_exercises(canonical):
-        urdf_str = _build_urdf_for(
-            exercise_name,
-            body_mass=args.mass,
-            height=args.height,
-            plate_mass_per_side=args.plates,
-        )
-
-        if args.export is not None:
-            _write_export(args.export, urdf_str)
-        elif not args.json:
-            _emit_urdf(exercise_name, urdf_str, args.output_dir)
-
-        if args.json:
-            results.append(
-                {
-                    "exercise": exercise_name,
-                    "urdf": urdf_str,
-                    "path": (
-                        str(args.export)
-                        if args.export is not None
-                        else (
-                            str(args.output_dir / f"{exercise_name}.urdf")
-                            if args.output_dir is not None
-                            else None
-                        )
-                    ),
-                    "parameters": {
-                        "mass": args.mass,
-                        "height": args.height,
-                        "plates": args.plates,
-                    },
-                    "success": True,
-                }
-            )
+    results = _build_and_collect(canonical, args)
 
     if args.json:
         json.dump(results, sys.stdout, indent=2)

--- a/src/pinocchio_models/__main__.py
+++ b/src/pinocchio_models/__main__.py
@@ -1,10 +1,15 @@
 """CLI entry point for Pinocchio model generation.
 
-Usage::
+Usage (legacy positional form, retained for backward compatibility)::
 
     python3 -m pinocchio_models squat
     python3 -m pinocchio_models bench_press --mass 90 --height 1.80 --plates 60
     python3 -m pinocchio_models all --output-dir ./models
+
+Usage (UpstreamDrift launcher contract, see issue #282)::
+
+    python3 -m pinocchio_models --list-exercises
+    python3 -m pinocchio_models --exercise gait --export /tmp/gait.urdf
 """
 
 from __future__ import annotations
@@ -43,13 +48,56 @@ _BUILDERS: dict[str, Callable[..., str]] = {
     "sit_to_stand": build_sit_to_stand_model,
 }
 
+# Aliases from manifest-declared IDs to builder keys. The model_pack
+# manifest uses the short name ``squat``; the legacy CLI keeps
+# ``back_squat`` for backward compatibility.
+_MANIFEST_ID_ALIASES: dict[str, str] = {
+    "squat": "back_squat",
+}
+
+
+def _manifest_choices() -> list[str]:
+    """Return the union of builder keys and manifest aliases."""
+    return sorted({*VALID_EXERCISE_NAMES, *_MANIFEST_ID_ALIASES.keys()})
+
 
 def _add_exercise_argument(parser: argparse.ArgumentParser) -> None:
-    """Add the positional ``exercise`` argument (choices + ``all``)."""
+    """Add the positional ``exercise`` argument plus ``--exercise`` flag.
+
+    Accepts the legacy positional form as well as the
+    ``--exercise <name>`` flag required by the UpstreamDrift launcher
+    contract (issue #282).
+    """
     parser.add_argument(
         "exercise",
-        choices=[*sorted(VALID_EXERCISE_NAMES), "all"],
+        nargs="?",
+        default=None,
+        choices=[*_manifest_choices(), "all"],
         help="Exercise to generate (or 'all' for all exercises).",
+    )
+    parser.add_argument(
+        "--exercise",
+        dest="exercise_flag",
+        choices=_manifest_choices(),
+        default=None,
+        help=(
+            "Exercise to generate (UpstreamDrift launcher form). "
+            "Mutually exclusive with the positional 'exercise' argument."
+        ),
+    )
+    parser.add_argument(
+        "--list-exercises",
+        action="store_true",
+        help="List the manifest-declared exercise IDs and exit.",
+    )
+    parser.add_argument(
+        "--export",
+        type=Path,
+        default=None,
+        help=(
+            "Write the generated URDF to this file path "
+            "(launcher contract: implies a single exercise selection)."
+        ),
     )
 
 
@@ -118,6 +166,28 @@ def _validate_cli_args(
         parser.error(f"--height must be positive, got {args.height}")
     if args.plates < 0:
         parser.error(f"--plates must be non-negative, got {args.plates}")
+    if args.exercise is not None and args.exercise_flag is not None:
+        parser.error(
+            "specify the exercise either positionally or via --exercise, not both"
+        )
+
+
+def _resolve_exercise_selection(
+    parser: argparse.ArgumentParser, args: argparse.Namespace
+) -> str | None:
+    """Return the canonical builder key for the requested exercise.
+
+    Honors both the legacy positional argument and the ``--exercise``
+    flag, applying manifest aliases (e.g. ``squat`` -> ``back_squat``).
+    Returns ``None`` only when no selection was made (e.g. for
+    ``--list-exercises``).
+    """
+    raw = args.exercise_flag if args.exercise_flag is not None else args.exercise
+    if raw is None:
+        return None
+    if raw == "all":
+        return "all"
+    return _MANIFEST_ID_ALIASES.get(raw, raw)
 
 
 def _emit_urdf(
@@ -163,6 +233,22 @@ def _build_urdf_for(
     )
 
 
+def _write_export(export_path: Path, urdf_str: str) -> None:
+    """Write *urdf_str* directly to *export_path* (launcher contract)."""
+    export_path.parent.mkdir(parents=True, exist_ok=True)
+    export_path.write_text(urdf_str, encoding="utf-8")
+    logger.info("Wrote %s", export_path)
+
+
+def _emit_list_exercises() -> int:
+    """Print manifest-declared exercise IDs, one per line, and return 0."""
+    from pinocchio_models.model_pack import list_exercises
+
+    sys.stdout.write("\n".join(list_exercises()))
+    sys.stdout.write("\n")
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     """CLI entry point for Pinocchio model generation.
 
@@ -181,8 +267,21 @@ def main(argv: list[str] | None = None) -> int:
         format="%(levelname)s: %(message)s",
     )
 
+    if args.list_exercises:
+        return _emit_list_exercises()
+
+    canonical = _resolve_exercise_selection(parser, args)
+    if canonical is None:
+        parser.error(
+            "an exercise must be selected via the positional argument, "
+            "--exercise, or --list-exercises"
+        )
+
+    if args.export is not None and canonical == "all":
+        parser.error("--export requires a single exercise (got 'all')")
+
     results: list[dict[str, object]] = []
-    for exercise_name in _selected_exercises(args.exercise):
+    for exercise_name in _selected_exercises(canonical):
         urdf_str = _build_urdf_for(
             exercise_name,
             body_mass=args.mass,
@@ -190,10 +289,10 @@ def main(argv: list[str] | None = None) -> int:
             plate_mass_per_side=args.plates,
         )
 
-        if not args.json:
+        if args.export is not None:
+            _write_export(args.export, urdf_str)
+        elif not args.json:
             _emit_urdf(exercise_name, urdf_str, args.output_dir)
-        else:
-            _ = None
 
         if args.json:
             results.append(
@@ -201,9 +300,13 @@ def main(argv: list[str] | None = None) -> int:
                     "exercise": exercise_name,
                     "urdf": urdf_str,
                     "path": (
-                        str(args.output_dir / f"{exercise_name}.urdf")
-                        if args.output_dir is not None
-                        else None
+                        str(args.export)
+                        if args.export is not None
+                        else (
+                            str(args.output_dir / f"{exercise_name}.urdf")
+                            if args.output_dir is not None
+                            else None
+                        )
                     ),
                     "parameters": {
                         "mass": args.mass,

--- a/src/pinocchio_models/model_pack.py
+++ b/src/pinocchio_models/model_pack.py
@@ -1,0 +1,110 @@
+"""Model-pack manifest entry point for UpstreamDrift integration.
+
+Implements the ``model_pack/v1`` contract registered under
+``[project.entry-points."biomech.model_pack"]`` so the UpstreamDrift
+launcher can discover this package without importing exercise modules.
+
+See ``model_pack.yaml`` at the repo root for the canonical manifest and
+the schema reference in
+``D-sorganization/UpstreamDrift#5199``
+(``src/shared/python/biomech/schemas/model_pack_v1.json``).
+"""
+
+from __future__ import annotations
+
+from importlib import resources
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+_MANIFEST_FILENAME: str = "model_pack.yaml"
+
+
+def _load_manifest_text() -> str:
+    """Return the raw text of the packaged ``model_pack.yaml``.
+
+    The manifest is shipped inside the wheel via ``[tool.hatch.build]``
+    so ``importlib.resources`` resolves it whether the package is
+    installed normally or in editable mode.
+    """
+    pkg = resources.files("pinocchio_models")
+    candidate = pkg / _MANIFEST_FILENAME
+    if candidate.is_file():
+        return candidate.read_text(encoding="utf-8")
+    # Editable install / source checkout fallback: walk up from the
+    # package directory to find the repo-root manifest.
+    pkg_path = Path(str(pkg)).resolve()
+    for parent in (pkg_path, *pkg_path.parents):
+        repo_manifest = parent / _MANIFEST_FILENAME
+        if repo_manifest.is_file():
+            return repo_manifest.read_text(encoding="utf-8")
+    raise FileNotFoundError(
+        f"Could not locate {_MANIFEST_FILENAME} alongside pinocchio_models."
+    )
+
+
+def manifest() -> dict[str, Any]:
+    """Return the parsed ``model_pack.yaml`` manifest as a dictionary.
+
+    Returns:
+        Parsed manifest with at minimum the keys declared in the
+        ``model_pack/v1`` schema: ``schema``, ``repo``, ``package``,
+        ``engine``, ``engine_version``, ``format``, ``models_root``,
+        ``exercises``.
+    """
+    data = yaml.safe_load(_load_manifest_text())
+    if not isinstance(data, dict):
+        raise ValueError(f"{_MANIFEST_FILENAME} must contain a YAML mapping")
+    return data
+
+
+def resolve() -> Path:
+    """Return the absolute path to the directory containing exercise models.
+
+    The path is the ``models_root`` declared in ``model_pack.yaml``,
+    resolved against the repository root (one level above the
+    ``pinocchio_models`` package directory in editable installs, or the
+    package directory itself in wheel installs that ship exercises).
+    """
+    data = manifest()
+    models_root = data.get("models_root")
+    if not isinstance(models_root, str) or not models_root:
+        raise ValueError("manifest is missing a non-empty 'models_root' entry")
+
+    pkg = resources.files("pinocchio_models")
+    pkg_path = Path(str(pkg)).resolve()
+
+    # Search upward for a directory containing the declared models_root.
+    for parent in (pkg_path, *pkg_path.parents):
+        candidate = parent / models_root
+        if candidate.is_dir():
+            return candidate.resolve()
+
+    # Final fallback: package-local ``exercises/`` directory (wheel layout).
+    fallback = pkg_path / "exercises"
+    if fallback.is_dir():
+        return fallback.resolve()
+    raise FileNotFoundError(
+        f"models_root '{models_root}' could not be resolved from {pkg_path}"
+    )
+
+
+def list_exercises() -> list[str]:
+    """Return the ordered list of exercise IDs declared in the manifest."""
+    data = manifest()
+    exercises = data.get("exercises", [])
+    if not isinstance(exercises, list):
+        raise ValueError("manifest 'exercises' entry must be a list")
+    out: list[str] = []
+    for entry in exercises:
+        if not isinstance(entry, dict):
+            raise ValueError("each exercise entry must be a mapping")
+        exercise_id = entry.get("id")
+        if not isinstance(exercise_id, str) or not exercise_id:
+            raise ValueError("each exercise entry requires a non-empty 'id'")
+        out.append(exercise_id)
+    return out
+
+
+__all__ = ["list_exercises", "manifest", "resolve"]

--- a/tests/test_model_pack.py
+++ b/tests/test_model_pack.py
@@ -1,0 +1,195 @@
+"""Tests for the model-pack manifest and launcher entry point.
+
+Mirrors the MuJoCo coordination test shape (see UpstreamDrift #5179 /
+#5184). The live-pinocchio assertions are marked ``live_simulation``
+so they are skipped in default CI but exercised on rigs with the real
+``pin`` package available.
+"""
+
+from __future__ import annotations
+
+import importlib
+import subprocess
+import sys
+import tempfile
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import pytest
+import yaml
+
+from pinocchio_models import model_pack
+
+# Exercises that require Pinocchio's floating base via
+# ``pin.JointModelFreeFlyer()``. Per repo CLAUDE.md, every exercise in
+# this package uses the free-flyer floating base; this set documents
+# the contract for the launcher integration.
+_FLOATING_BASE_EXERCISES: frozenset[str] = frozenset(
+    {
+        "squat",
+        "deadlift",
+        "bench_press",
+        "snatch",
+        "clean_and_jerk",
+        "gait",
+        "sit_to_stand",
+    }
+)
+
+_EXPECTED_EXERCISE_IDS: tuple[str, ...] = (
+    "squat",
+    "deadlift",
+    "bench_press",
+    "snatch",
+    "clean_and_jerk",
+    "gait",
+    "sit_to_stand",
+)
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parent.parent
+
+
+class TestManifest:
+    def test_manifest_returns_mapping(self) -> None:
+        data = model_pack.manifest()
+        assert isinstance(data, dict)
+
+    def test_schema_is_model_pack_v1(self) -> None:
+        assert model_pack.manifest()["schema"] == "model_pack/v1"
+
+    def test_engine_metadata(self) -> None:
+        data = model_pack.manifest()
+        assert data["engine"] == "pinocchio"
+        assert data["engine_version"] == ">=2.7"
+        assert data["format"] == "urdf"
+        assert data["anthropometrics"] == "winter_2009"
+
+    def test_addons_block_present(self) -> None:
+        data = model_pack.manifest()
+        addons = data.get("addons")
+        assert isinstance(addons, dict)
+        for name in ("gepetto", "pink", "crocoddyl"):
+            assert addons.get(name) == "optional"
+
+    def test_repo_root_yaml_matches_loaded_manifest(self) -> None:
+        on_disk = yaml.safe_load(
+            (_repo_root() / "model_pack.yaml").read_text(encoding="utf-8")
+        )
+        assert model_pack.manifest() == on_disk
+
+
+class TestListExercises:
+    def test_returns_expected_ids_in_order(self) -> None:
+        assert model_pack.list_exercises() == list(_EXPECTED_EXERCISE_IDS)
+
+    def test_all_ids_are_floating_base_exercises(self) -> None:
+        for exercise_id in model_pack.list_exercises():
+            assert exercise_id in _FLOATING_BASE_EXERCISES
+
+
+class TestResolve:
+    def test_resolve_returns_existing_directory(self) -> None:
+        root = model_pack.resolve()
+        assert root.is_dir(), f"{root} does not exist"
+
+    def test_resolve_contains_each_declared_exercise(self) -> None:
+        root = model_pack.resolve()
+        for exercise_id in _EXPECTED_EXERCISE_IDS:
+            assert (root / exercise_id).is_dir(), (
+                f"missing exercise directory: {exercise_id}"
+            )
+
+
+class TestEntryPointDiscoverable:
+    """The biomech.model_pack entry point must be discoverable by importers."""
+
+    def test_module_exposes_required_callables(self) -> None:
+        mod = importlib.import_module("pinocchio_models.model_pack")
+        for attr in ("resolve", "manifest", "list_exercises"):
+            assert callable(getattr(mod, attr))
+
+
+class TestLauncherCLI:
+    def test_list_exercises_flag_prints_ids(self) -> None:
+        result = subprocess.run(
+            [sys.executable, "-m", "pinocchio_models", "--list-exercises"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr
+        lines = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+        assert lines == list(_EXPECTED_EXERCISE_IDS)
+
+    @pytest.mark.parametrize("exercise_id", _EXPECTED_EXERCISE_IDS)
+    def test_export_writes_valid_urdf(self, exercise_id: str) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            export_path = Path(tmpdir) / f"{exercise_id}.urdf"
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "pinocchio_models",
+                    "--exercise",
+                    exercise_id,
+                    "--export",
+                    str(export_path),
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            assert result.returncode == 0, result.stderr
+            assert export_path.exists()
+            root = ET.fromstring(export_path.read_text(encoding="utf-8"))
+            assert root.tag == "robot"
+            # Every exercise has at least one link and one joint.
+            assert len(root.findall("link")) > 0
+            assert len(root.findall("joint")) > 0
+
+
+@pytest.mark.live_simulation
+class TestPinocchioParse:
+    """Live-simulation tests: require the real ``pin`` package.
+
+    These tests use ``pinocchio.buildModelFromUrdf`` per the issue
+    contract. They are skipped in default CI and run only on rigs with
+    Pinocchio installed.
+    """
+
+    @pytest.mark.parametrize("exercise_id", _EXPECTED_EXERCISE_IDS)
+    def test_parse_via_build_model_from_urdf(self, exercise_id: str) -> None:
+        pin = pytest.importorskip("pinocchio", reason="pin package not installed")
+        if not hasattr(pin, "buildModelFromUrdf"):
+            pytest.skip("pin.buildModelFromUrdf not available in this build")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            export_path = Path(tmpdir) / f"{exercise_id}.urdf"
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "pinocchio_models",
+                    "--exercise",
+                    exercise_id,
+                    "--export",
+                    str(export_path),
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            assert result.returncode == 0, result.stderr
+
+            # Build with the free-flyer floating base where required.
+            if exercise_id in _FLOATING_BASE_EXERCISES:
+                model = pin.buildModelFromUrdf(
+                    str(export_path), pin.JointModelFreeFlyer()
+                )
+                # nq must include the 7-DOF floating base (3 trans + 4 quat).
+                assert model.nq >= 7
+            else:
+                model = pin.buildModelFromUrdf(str(export_path))
+                assert model.nq > 0

--- a/tests/test_pinocchio_api_contract.py
+++ b/tests/test_pinocchio_api_contract.py
@@ -1,0 +1,84 @@
+"""Pinocchio API contract guard tests.
+
+Per UpstreamDrift CLAUDE.md (mirrored in this repo's CLAUDE.md):
+
+    Pinocchio API: NO ``computeTotalEnergy``; use ``computeKineticEnergy``
+    + ``computePotentialEnergy`` separately.
+
+These tests assert that the API we *actually* call still exists with
+the expected signature, and that ``computeTotalEnergy`` is *not*
+present. They surface upstream regressions here, in Pinocchio_Models,
+rather than downstream in UpstreamDrift launcher code.
+
+The live-pinocchio assertions are marked ``live_simulation`` so they
+are skipped by default CI but exercised on rigs with the real ``pin``
+package installed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.live_simulation
+class TestPinocchioEnergyAPI:
+    """Guard the energy-API contract Pinocchio_Models depends on."""
+
+    def test_compute_total_energy_is_absent(self) -> None:
+        """``computeTotalEnergy`` must not exist. If it ever appears,
+        downstream code that learned to depend on it would break the
+        very Pinocchio versions we support."""
+        pin = pytest.importorskip("pinocchio", reason="pin package not installed")
+        assert not hasattr(pin, "computeTotalEnergy"), (
+            "pinocchio.computeTotalEnergy reappeared upstream; update "
+            "the contract guard and the documentation in CLAUDE.md."
+        )
+
+    def test_kinetic_and_potential_energy_callables_exist(self) -> None:
+        pin = pytest.importorskip("pinocchio", reason="pin package not installed")
+        assert callable(getattr(pin, "computeKineticEnergy", None))
+        assert callable(getattr(pin, "computePotentialEnergy", None))
+
+    def test_total_energy_is_sum_of_kinetic_and_potential(self) -> None:
+        """Numerical sanity check on a tiny model: total = T + V."""
+        pin = pytest.importorskip("pinocchio", reason="pin package not installed")
+        import numpy as np
+
+        from pinocchio_models.exercises.gait.gait_model import build_gait_model
+
+        urdf_str = build_gait_model()
+        if hasattr(pin, "buildModelFromXML"):
+            model = pin.buildModelFromXML(urdf_str, pin.JointModelFreeFlyer())
+        else:
+            pytest.skip("pin.buildModelFromXML not available in this build")
+        data = model.createData()
+
+        q = pin.neutral(model)
+        v = np.zeros(model.nv)
+
+        kinetic = pin.computeKineticEnergy(model, data, q, v)
+        potential = pin.computePotentialEnergy(model, data, q)
+        expected_total = kinetic + potential
+
+        # Contract: there is no ``pin.computeTotalEnergy``; the caller
+        # must sum kinetic + potential explicitly. We assert the sum
+        # matches itself (sanity) and that no helper is silently masking
+        # the API gotcha.
+        assert np.isfinite(expected_total)
+        assert not hasattr(pin, "computeTotalEnergy")
+
+
+class TestEnergyAPIDocumentation:
+    """Static guards that always run (no Pinocchio required)."""
+
+    def test_repo_claude_md_documents_gotcha(self) -> None:
+        from pathlib import Path
+
+        claude_md = (Path(__file__).resolve().parent.parent / "CLAUDE.md").read_text(
+            encoding="utf-8"
+        )
+        assert "computeTotalEnergy" in claude_md, (
+            "CLAUDE.md must continue to document the missing-API gotcha."
+        )
+        assert "computeKineticEnergy" in claude_md
+        assert "computePotentialEnergy" in claude_md


### PR DESCRIPTION
## Summary

Implements the Pinocchio_Models side of the UpstreamDrift biomechanics-fleet integration ([UpstreamDrift#5179](https://github.com/D-sorganization/UpstreamDrift/issues/5179)). Publishes the stable launcher-discovery surface UpstreamDrift uses to find and host this repo's exercise content.

- `model_pack.yaml` (schema `model_pack/v1`) at repo root; force-included in the wheel via hatch so `resolve()` works in both source and installed layouts. Declares `engine=pinocchio` (`>=2.7`), `format=urdf`, plus the optional `gepetto` / `pink` / `crocoddyl` addons.
- `pinocchio_models.model_pack`: `resolve()`, `manifest()`, `list_exercises()`.
- `[project.entry-points."biomech.model_pack"]` registered in `pyproject.toml`.
- CLI gains `--exercise` / `--export` / `--list-exercises` to match the launcher contract; legacy positional `exercise` and `--output-dir` are preserved for backwards compatibility. Manifest IDs (`squat`) alias to legacy builder keys (`back_squat`) so fleet-wide ID parity holds without breaking back-compat.
- `ci-standard.yml` gets a verify step that smoke-imports the discovery surface.
- Adds `test_pinocchio_api_contract.py` — guard tests for the energy-API quirk called out in CLAUDE.md (no `computeTotalEnergy`; use `computeKineticEnergy` + `computePotentialEnergy` separately), so the launcher integration cannot regress it.

Closes #282.

## Test plan

- [x] `pytest tests/test_model_pack.py tests/test_pinocchio_api_contract.py` — 19 tests pass (10 `live_simulation` deselected by default).
- [x] `ruff check` — clean.
- [x] `ruff format --check` — clean.
- [x] `mypy src` — no issues on 65 sources.
- [ ] CI Standard suite stays green.
- [ ] `live_simulation` `TestPinocchioParse` and energy-API guards run in environments with `pin` installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)