### PR TITLE
ci(standard): parallelize jobs after pick-runner + fail-fast: false on matrix

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -171,10 +171,10 @@ jobs:
   tests:
     needs:
       - pick-runner
-      - quality-gate
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     timeout-minutes: 15
     strategy:
+      fail-fast: false
       max-parallel: 1
       matrix:
         python: ["3.10", "3.11", "3.12"]
@@ -229,7 +229,6 @@ jobs:
   benchmarks:
     needs:
       - pick-runner
-      - quality-gate
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     timeout-minutes: 10
     steps:
@@ -264,7 +263,6 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     needs:
       - pick-runner
-      - quality-gate
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
Part of 2026-05-17 fleet CI parallelization campaign (15/15 complete with this PR). Pattern: jobs flattened from `needs: [pick-runner, quality-gate]` to `needs: pick-runner` since `quality-gate` declares no `outputs:` and no downstream step consumes its outputs. Matrix `fail-fast: false` added so all matrix entries report failures independently. Failure-visibility benefit: agents remediating failing PRs see ALL failures on the first run instead of one-fix-at-a-time across multiple queue cycles.

## Changes
- `tests`: dropped `quality-gate` from `needs:`
- `benchmarks`: dropped `quality-gate` from `needs:`
- `profiling`: dropped `quality-gate` from `needs:`
- `tests` matrix: added `fail-fast: false` (kept `max-parallel: 1`)