### PR TITLE
⚡ Bolt: [performance improvement] Precompute strings in set_joint_default loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -52,3 +52,7 @@
 ## 2026-05-19 - URDF Serialization Overhead (f-string collapsing)
 **Learning:** In recursive `xml.etree.ElementTree` string builders, avoiding nested helper function calls for escaping text/attributes and utilizing `f-strings` to collapse multiple list `.append()` calls results in ~40% faster serialization speeds. Since URDF structures often contain basic numerical strings rather than complex text requiring heavy escaping, the inline string check short-circuits faster than a function call.
 **Action:** When creating text generators traversing large recursive tree structures on a hot path, inline simple guard logic and minimize operations modifying the accumulator (e.g. `append`).
+
+## 2026-05-24 - Precompute invariate values in hot loops
+**Learning:** During optimization of `set_joint_default`, it was noticed that inside a hot loop traversing `findall('joint')`, both `float_str(value)` and `f"{prefix}_"` were evaluated repeatedly for every joint.
+**Action:** When a loop contains values that don't change per iteration, pre-compute them outside the loop. In the case of `set_joint_default`, precomputing `val_str = float_str(value)` and `prefix_underscore = f"{prefix}_"` outside the loop decreased the total evaluation time measurably on big URDF tree models.

--- a/SPEC.md
+++ b/SPEC.md
@@ -307,3 +307,4 @@ The repository is in active maintenance. Shared model generation is established,
 | 2026-05-05 | 1.0.16 | Updated CI workflow artifact uploads to `actions/upload-artifact@v7` and documented that workflow contract tests enforce artifact presence rather than a pinned action major. |
 | 2026-05-19 | 1.0.17 | Optimized URDF serialization bypassing xml.etree.ElementTree.tostring internal overhead. |
 | 2026-06-25 | 1.0.18 | Optimized XML text escaping by inlining logic in `serialize_model` recursive inner loop. |
+| 2026-05-24 | 1.0.19 | Optimized `set_joint_default` by precomputing invariant strings before iteration. |

--- a/src/pinocchio_models/shared/utils/urdf_helpers.py
+++ b/src/pinocchio_models/shared/utils/urdf_helpers.py
@@ -406,12 +406,14 @@ def set_joint_default(
         E.g. ``exact_suffix="_flex"`` with ``prefix="hip"`` matches
         ``hip_l_flex`` and ``hip_r_flex`` but not ``hip_l_adduct``.
     """
+    val_str = float_str(value)
+    prefix_underscore = f"{prefix}_"
     for joint in robot.findall("joint"):
         name = joint.get("name", "")
-        if name == prefix or name.startswith(f"{prefix}_"):
+        if name == prefix or name.startswith(prefix_underscore):
             if exact_suffix is not None and not name.endswith(exact_suffix):
                 continue
-            joint.set("initial_position", float_str(value))
+            joint.set("initial_position", val_str)
 
 
 def _import_pinocchio() -> Any:


### PR DESCRIPTION
💡 **What:** 
Moved the computation of `float_str(value)` and `f"{prefix}_"` outside the `for joint in robot.findall("joint"):` loop in `src/pinocchio_models/shared/utils/urdf_helpers.py:set_joint_default()`.

🎯 **Why:** 
The `prefix` and `value` parameters do not change during iteration. Evaluating the f-string and the `float_str` function for every single joint unnecessarily wastes CPU cycles, especially on larger URDF trees where `set_joint_default` is called sequentially on many elements. Precomputing them hoists the repeated work.

📊 **Impact:** 
Improves execution speed of the model builder by stripping redundant string allocations and function calls from a hot traversal loop. 

🔬 **Measurement:** 
Benchmarked locally by isolating `set_joint_default` calls inside a tight loop simulating model construction. Execution time decreased measurably compared to evaluating the string operations dynamically on every loop iteration. Run `PYTHONPATH=src python3 -m pytest tests/benchmarks/ -m slow` to verify overall benchmark stability.

---
*PR created automatically by Jules for task [13167776083009062470](https://jules.google.com/task/13167776083009062470) started by @dieterolson*