### PR TITLE
⚡ Bolt: [performance improvement] Optimize link name and joint collection loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -99,3 +99,6 @@
 ## 2026-06-25 - Avoid inline imports in high-frequency functions
 **Learning:** In python, inline or local imports inside a function body incur a small overhead on every function call because python has to check `sys.modules` and acquire the import lock. When these functions (like contract validations `require_positive`) are called thousands of times per URDF model generation, this overhead accumulates into a measurable bottleneck.
 **Action:** Always place imports at the global module level, especially for functions that sit in the hot path. Moving local imports to the top level reduces execution time for 1M calls from ~0.710s to ~0.217s.
+## 2024-06-27 - Local caching of append/add methods
+**Learning:** Even on modern Python versions (3.11+), when iterating over large datasets or deeply nested structures like URDF XML trees in a tight `for` loop, repeatedly calling methods like `.append` or `.add` on variables incurs a dictionary attribute lookup overhead.
+**Action:** Always consider assigning methods to local variables (e.g., `list_append = my_list.append`) outside the loop for high-frequency or deep iteration loops to squeeze out extra micro-performance. Ensure a descriptive comment is added to explain why this unusual code structure is present, matching Bolt's requirement.

--- a/src/pinocchio_models/shared/contracts/postconditions.py
+++ b/src/pinocchio_models/shared/contracts/postconditions.py
@@ -69,6 +69,11 @@ def _collect_link_names_and_joints(
     link_names: set[str] = set()
     joints: list[ET.Element] = []
 
+    # ⚡ Bolt Optimization: Resolving list/set method attributes outside the hot loop
+    # prevents repeated dictionary lookups during deep URDF tree iterations,
+    # lowering loop overhead and improving generation OPS.
+    link_names_add = link_names.add
+    joints_append = joints.append
     for el in root.iter():
         tag = el.tag
         if type(tag) is not str:
@@ -83,9 +88,9 @@ def _collect_link_names_and_joints(
         if tag == "link":
             name = el.get("name")
             if name:
-                link_names.add(name)
+                link_names_add(name)
         elif tag == "joint":
-            joints.append(el)
+            joints_append(el)
 
     return link_names, joints
 


### PR DESCRIPTION
## 💡 What
Optimized `_collect_link_names_and_joints` in `src/pinocchio_models/shared/contracts/postconditions.py` by caching the `.add` and `.append` methods as local variables outside the iteration loop.

## 🎯 Why
When iterating over deeply nested URDF tree models in Python, method lookups on objects (e.g. `list.append` or `set.add`) incur dictionary attribute lookup overhead on every iteration. Storing references to these bound methods outside the hot path avoids this overhead.

## 📊 Impact
This micro-optimization marginally lowers loop overhead, slightly improving operations per second (OPS) during URDF generation and validation pipelines.

## 🔬 Measurement
Verified by running `PYTHONPATH=src python3 -m pytest tests/benchmarks/test_model_generation_benchmark.py -m slow`, resulting in successful passes and consistent performance numbers for the various models.

---
*PR created automatically by Jules for task [17014855253225923644](https://jules.google.com/task/17014855253225923644) started by @dieterolson*