### PR TITLE
⚡ Bolt: Optimize ElementTree ElementPath search with iter

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -207,3 +207,7 @@
 
 **Learning:** In URDF generation's string escaping logic (`_serialize`), wrapping individual `.replace()` calls inside a large compound `if` block with `in` conditions (e.g., `if "&" in v or "<" in v or ">" in v...`) is slightly slower than simply testing each character individually (e.g., `if "&" in v: v = v.replace(...)`). The boolean logic overhead of the compound check in Python outweighs the cost of sequential `in` checks because most attributes do not contain these special characters, and `in` on short attribute strings is highly optimized in C.
 **Action:** When escaping XML/URDF strings for special characters in hot loops, use separate `if "char" in string:` checks instead of grouping them all into one large `if` condition. This speeds up string validation by eliminating the compound evaluation overhead.
+
+## 2026-08-04 - Avoid ElementPath searching for known elements
+**Learning:** Using `ElementTree.find()` with `ElementPath` strings (e.g. `robot.find(".//link")`) is slow because it recursively parses and scans the entire tree. For elements whose structural location is known, simple traversal techniques (like `iter` or manual iteration) are much faster.
+**Action:** Replace `ElementTree.find()` involving `ElementPath` with `iter()` (or manual iteration) when locating specific known elements inside flat or well-structured trees.

--- a/src/pinocchio_models/shared/body/body_model.py
+++ b/src/pinocchio_models/shared/body/body_model.py
@@ -255,10 +255,16 @@ def _add_foot_collision(
         side: ``'l'`` or ``'r'``.
         dims: ``(length, width, height)`` of the sole contact box in metres.
     """
-    foot_link = robot.find(f".//link[@name='foot_{side}']")
+    target_name = f"foot_{side}"
+    foot_link = None
+    for link in robot.iter("link"):
+        if link.get("name") == target_name:
+            foot_link = link
+            break
+
     if foot_link is not None:
         collision = ET.SubElement(foot_link, "collision")
-        ET.SubElement(collision, "origin", xyz="0 0 -0.01", rpy="0 0 0")
+        ET.SubElement(collision, "origin", {"xyz": "0 0 -0.01", "rpy": "0 0 0"})
         collision.append(make_box_geometry(*dims))
 
 

--- a/tests/unit/test_cli_helpers.py
+++ b/tests/unit/test_cli_helpers.py
@@ -21,7 +21,7 @@ def test_add_exercise_argument_accepts_known_and_all() -> None:
     """Known exercise names and the ``all`` keyword parse successfully."""
     p = argparse.ArgumentParser()
     cli._add_exercise_argument(p)
-    known = sorted(VALID_EXERCISE_NAMES)[0]
+    known = min(VALID_EXERCISE_NAMES)
     assert p.parse_args([known]).exercise == known
     assert p.parse_args(["all"]).exercise == "all"
 
@@ -59,7 +59,7 @@ def test_add_output_arguments_defaults_and_flags() -> None:
 def test_create_parser_composes_all_groups() -> None:
     """End-to-end: the composed parser accepts one command from each group."""
     p = cli._create_parser()
-    known = sorted(VALID_EXERCISE_NAMES)[0]
+    known = min(VALID_EXERCISE_NAMES)
     ns = p.parse_args(
         [known, "--mass", "70", "--height", "1.7", "--plates", "10", "-v"]
     )


### PR DESCRIPTION
⚡ Bolt Optimization:
1. Replaced slow `ElementPath` search `robot.find(f".//link[@name='foot_{side}']")` with `robot.iter("link")` in `_add_foot_collision` because `ElementPath` recursively parses the tree, adding overhead.
2. Refactored `ET.SubElement` keyword arguments into explicit attribute dictionaries (e.g. `{"xyz": "0 0 -0.01", "rpy": "0 0 0"}`) to avoid Python argument packing/unpacking overhead.
3. Used `min()` instead of `sorted()[0]` in tests to comply with `FURB192`.
4. Documented the learnings in `.jules/bolt.md`.

---
*PR created automatically by Jules for task [14833027292639596366](https://jules.google.com/task/14833027292639596366) started by @dieterolson*